### PR TITLE
.gitignore に /coverage を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 !/log/.keep
 /tmp
 *.swp
+/coverage


### PR DESCRIPTION
コードカバレッジ計測の一時ファイルが git で引っかかってしまうので、.gitignore に追加しました。