### PR TITLE
Travis CI: テスト対象に Ruby 2.3.3 を追加する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.3.0
   - 2.3.1
+  - 2.3.3
 services:
   - mysql
 before_script:


### PR DESCRIPTION
Travis CIにRuby 2.3系の最新版の2.3.3が追加されていましたので、テスト対象に設定しました。