### PR TITLE
irc: 自分自身の発言を保存できるようにする

### DIFF
--- a/lib/ircs/plugins/base.rb
+++ b/lib/ircs/plugins/base.rb
@@ -20,7 +20,7 @@ module LogArchiver
       # @param [Cinch::Message] m
       # @param [String] message 送信するメッセージ
       # @return [void]
-      def send(m, message)
+      def send_and_record(m, message)
         m.target.send(message, true)
         @logger.warn("<#{m.channel}>: #{message}")
 

--- a/lib/ircs/plugins/base.rb
+++ b/lib/ircs/plugins/base.rb
@@ -26,12 +26,13 @@ module LogArchiver
 
         synchronize(RECORD_MESSAGE) do
           ActiveRecord::Base.connection_pool.with_connection do
-            channel = ::Channel.find_by(name: m.channel.name[1..-1],
-                                        logging_enabled: true)
-            next nil unless channel
+            next nil unless channel =
+              ::Channel.find_by(
+                name: m.channel.name[1..-1],
+                logging_enabled: true
+              )
 
-            next nil unless user = bot
-            irc_user = IrcUser.find_or_create_by!(user: user.user, host: user.host)
+            irc_user = IrcUser.find_or_create_by!(user: bot.user, host: bot.host)
 
             MessageDate.find_or_create_by!(channel: channel, date: m.time.to_date)
 

--- a/lib/ircs/plugins/base.rb
+++ b/lib/ircs/plugins/base.rb
@@ -3,7 +3,7 @@
 module LogArchiver
   module Plugin
     # プラグインのひな形
-    class Template
+    class Base
       include Cinch::Plugin
 
       RECORD_MESSAGE = :record_message

--- a/lib/ircs/plugins/channel_sync.rb
+++ b/lib/ircs/plugins/channel_sync.rb
@@ -6,7 +6,7 @@ module LogArchiver
   module Plugin
     # DB からチャンネル情報を読み出し、設定と実際の接続状態を比較する
     # 必要なチャンネルに JOIN する
-    class ChannelSync < Template
+    class ChannelSync < Base
       include Cinch::Plugin
 
       set(plugin_name: 'ChannelSync')

--- a/lib/ircs/plugins/channel_sync.rb
+++ b/lib/ircs/plugins/channel_sync.rb
@@ -1,6 +1,6 @@
 # vim: fileencoding=utf-8
 
-require_relative 'plugin_template'
+require_relative 'base'
 
 module LogArchiver
   module Plugin

--- a/lib/ircs/plugins/kick_back.rb
+++ b/lib/ircs/plugins/kick_back.rb
@@ -31,7 +31,7 @@ module LogArchiver
           @logger.warn("#{m.channel} から KICK されたため、JOIN し直しました")
           sleep 1
           (JOIN_MESSAGE % m.channel.to_s).each_line do |line|
-            send(m, line)
+            send_and_record(m, line)
           end
         end
       end

--- a/lib/ircs/plugins/kick_back.rb
+++ b/lib/ircs/plugins/kick_back.rb
@@ -5,7 +5,7 @@ require_relative 'plugin_template'
 module LogArchiver
   module Plugin
     # KICK されたとき、ログ取得対象チャンネルだった場合 JOIN しなおす
-    class KickBack < Template
+    class KickBack < Base
       include Cinch::Plugin
 
       set(plugin_name: 'KickBack')

--- a/lib/ircs/plugins/kick_back.rb
+++ b/lib/ircs/plugins/kick_back.rb
@@ -1,6 +1,6 @@
 # vim: fileencoding=utf-8
 
-require_relative 'plugin_template'
+require_relative 'base'
 
 module LogArchiver
   module Plugin

--- a/lib/ircs/plugins/kick_back.rb
+++ b/lib/ircs/plugins/kick_back.rb
@@ -31,8 +31,7 @@ module LogArchiver
           @logger.warn("#{m.channel} から KICK されたため、JOIN し直しました")
           sleep 1
           (JOIN_MESSAGE % m.channel.to_s).each_line do |line|
-            m.target.send(line, true)
-            @logger.warn("<#{m.channel}>: #{line}")
+            send(m, line)
           end
         end
       end

--- a/lib/ircs/plugins/login_nickserv.rb
+++ b/lib/ircs/plugins/login_nickserv.rb
@@ -7,7 +7,7 @@ require_relative 'plugin_template'
 module LogArchiver
   module Plugin
     # NickServ にログインする
-    class LoginNickserv < Template
+    class LoginNickserv < Base
       include Cinch::Plugin
 
       set(plugin_name: 'LoginNickserv')

--- a/lib/ircs/plugins/login_nickserv.rb
+++ b/lib/ircs/plugins/login_nickserv.rb
@@ -2,7 +2,7 @@
 
 require 'cinch'
 
-require_relative 'plugin_template'
+require_relative 'base'
 
 module LogArchiver
   module Plugin

--- a/lib/ircs/plugins/plugin_template.rb
+++ b/lib/ircs/plugins/plugin_template.rb
@@ -20,6 +20,60 @@ module LogArchiver
       def send(m, message)
         m.target.send(message, true)
       end
+
+      private
+
+      # メッセージを記録する
+      # @param [Cinch::Message] message Cinch から渡された IRC メッセージ
+      # @yieldparam [::Channel] channel チャンネル
+      # @yieldparam [IrcUser] irc_user IRC ユーザー
+      # @return [void]
+      def record_message(message)
+        return nil unless message.channel
+
+        synchronize(RECORD_MESSAGE) do
+          ActiveRecord::Base.connection_pool.with_connection do
+            channel = ::Channel.find_by(name: message.channel.name[1..-1],
+                                        logging_enabled: true)
+            next nil unless channel
+
+            next nil unless user = message.user
+            irc_user = IrcUser.find_or_create_by!(user: user.user, host: user.host)
+
+            MessageDate.find_or_create_by!(channel: channel, date: message.time.to_date)
+
+            yield(channel, irc_user)
+          end
+        end
+      end
+
+      # 複数のチャンネルにメッセージを記録する
+      # @param [Cinch::Message] message Cinch から渡された IRC メッセージ
+      # @param [Array<Cinch::Channel>] cinch_channels Cinch から渡されたチャンネルリスト
+      # @yieldparam [::Channel] channel チャンネル
+      # @yieldparam [IrcUser] irc_user IRC ユーザー
+      # @return [void]
+      def record_message_to_channels(message, cinch_channels)
+        channel_names_without_prefix =
+          cinch_channels.map { |channel| channel.name[1..-1] }
+
+        ActiveRecord::Base.connection_pool.with_connection do
+          synchronize(RECORD_MESSAGE) do
+            irc_user = nil
+            next [] unless user = message.user
+            channels = ::Channel.where(name: channel_names_without_prefix,
+                                       logging_enabled: true)
+            channels.each.map do |channel|
+              irc_user ||= IrcUser.find_or_create_by!(user: user.user,
+                                                      host: user.host)
+
+              MessageDate.find_or_create_by!(channel: channel, date: message.time.to_date)
+
+              yield(channel, irc_user)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/ircs/plugins/plugin_template.rb
+++ b/lib/ircs/plugins/plugin_template.rb
@@ -12,6 +12,14 @@ module LogArchiver
 
         @logger = config[:logger]
       end
+
+      # IRC へ発言し、データベースに保存する
+      # このメソッドを経由しないと、自分自身の発言が保存できない
+      # @param [Cinch::Message] m
+      # @param [String] message 送信するメッセージ
+      def send(m, message)
+        m.target.send(message, true)
+      end
     end
   end
 end

--- a/lib/ircs/plugins/save_log.rb
+++ b/lib/ircs/plugins/save_log.rb
@@ -117,59 +117,6 @@ module LogArchiver
         end
       end
 
-      private
-
-      # メッセージを記録する
-      # @param [Cinch::Message] message Cinch から渡された IRC メッセージ
-      # @yieldparam [::Channel] channel チャンネル
-      # @yieldparam [IrcUser] irc_user IRC ユーザー
-      # @return [void]
-      def record_message(message)
-        return nil unless message.channel
-
-        synchronize(RECORD_MESSAGE) do
-          ActiveRecord::Base.connection_pool.with_connection do
-            channel = ::Channel.find_by(name: message.channel.name[1..-1],
-                                        logging_enabled: true)
-            next nil unless channel
-
-            next nil unless user = message.user
-            irc_user = IrcUser.find_or_create_by!(user: user.user, host: user.host)
-
-            MessageDate.find_or_create_by!(channel: channel, date: message.time.to_date)
-
-            yield(channel, irc_user)
-          end
-        end
-      end
-
-      # 複数のチャンネルにメッセージを記録する
-      # @param [Cinch::Message] message Cinch から渡された IRC メッセージ
-      # @param [Array<Cinch::Channel>] cinch_channels Cinch から渡されたチャンネルリスト
-      # @yieldparam [::Channel] channel チャンネル
-      # @yieldparam [IrcUser] irc_user IRC ユーザー
-      # @return [void]
-      def record_message_to_channels(message, cinch_channels)
-        channel_names_without_prefix =
-          cinch_channels.map { |channel| channel.name[1..-1] }
-
-        ActiveRecord::Base.connection_pool.with_connection do
-          synchronize(RECORD_MESSAGE) do
-            irc_user = nil
-            next [] unless user = message.user
-            channels = ::Channel.where(name: channel_names_without_prefix,
-                                       logging_enabled: true)
-            channels.each.map do |channel|
-              irc_user ||= IrcUser.find_or_create_by!(user: user.user,
-                                                      host: user.host)
-
-              MessageDate.find_or_create_by!(channel: channel, date: message.time.to_date)
-
-              yield(channel, irc_user)
-            end
-          end
-        end
-      end
     end
   end
 end
@@ -187,3 +134,4 @@ class Cinch::IRC
     on_quit_original(msg, events)
   end
 end
+

--- a/lib/ircs/plugins/save_log.rb
+++ b/lib/ircs/plugins/save_log.rb
@@ -131,4 +131,3 @@ class Cinch::IRC
     on_quit_original(msg, events)
   end
 end
-

--- a/lib/ircs/plugins/save_log.rb
+++ b/lib/ircs/plugins/save_log.rb
@@ -11,8 +11,6 @@ module LogArchiver
     class SaveLog < Template
       include Cinch::Plugin
 
-      RECORD_MESSAGE = :record_message
-
       set(plugin_name: 'SaveLog')
 
       listen_to(:join, method: :on_join)
@@ -116,7 +114,6 @@ module LogArchiver
                                   message: m.message)
         end
       end
-
     end
   end
 end

--- a/lib/ircs/plugins/save_log.rb
+++ b/lib/ircs/plugins/save_log.rb
@@ -8,7 +8,7 @@ require 'pp'
 module LogArchiver
   module Plugin
     # DB にログを保存する
-    class SaveLog < Template
+    class SaveLog < Base
       include Cinch::Plugin
 
       set(plugin_name: 'SaveLog')

--- a/lib/ircs/plugins/save_log.rb
+++ b/lib/ircs/plugins/save_log.rb
@@ -2,7 +2,7 @@
 
 require 'cinch'
 require 'json'
-require_relative 'plugin_template'
+require_relative 'base'
 require 'pp'
 
 module LogArchiver


### PR DESCRIPTION
IRC へ発言するメソッドをプラグインテンプレートで共通化し、その中でデータベースに保存するようにした。
ログ出力も共通化メソッドに統合した。

issue: #1 

version_plugin ブランチに一度マージし、その後で version プラグインが共通化メソッドを使うように更新してから、master ブランチにマージしたい。