### PR TITLE
サイト名等の設定のモデルを作成し、その値を表示に反映する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem "simple_calendar", "~> 2.0"
 gem 'momentjs-rails', '~> 2.15'
 gem 'bootstrap3-datetimepicker-rails', '~> 4.17'
 
+# Markdown パーサ
+gem 'redcarpet'
+
 # 自動リンク
 gem 'rinku'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.2)
       json (~> 1.4)
+    redcarpet (3.4.0)
     rinku (2.0.2)
     ruby-progressbar (1.8.1)
     ruby_dep (1.4.0)
@@ -285,6 +286,7 @@ DEPENDENCIES
   mysql2 (>= 0.3.13, < 0.5)
   pry-rails
   rails (= 4.2.6)
+  redcarpet
   rinku
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -8,6 +8,10 @@ body {
   padding-bottom: 0.2em;
 }
 
+.text-on-homepage {
+  margin-bottom: 1em;
+}
+
 h1.title {
   text-align: center;
   font-weight: normal;

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,7 @@
 class WelcomeController < ApplicationController
   def index
+    @setting = Setting.get
+
     @invalid_model = nil
     @channel_browse = ChannelBrowse.new
     @message_search = MessageSearch.new

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,5 @@
 class WelcomeController < ApplicationController
   def index
-    @setting = Setting.get
-
     @invalid_model = nil
     @channel_browse = ChannelBrowse.new
     @message_search = MessageSearch.new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,12 @@
 module ApplicationHelper
+  # サイト名を返す
+  def site_title
+    @setting ||= Setting.get
+    @site_title ||= @setting.site_title
+  end
+
   # 既定の meta タグの内容を返す
   def default_meta_tags
-    setting = Setting.get
-    site_title = setting.site_title
-
     {
       site: site_title,
       reverse: true,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,16 @@
 module ApplicationHelper
   # 既定の meta タグの内容を返す
   def default_meta_tags
+    setting = Setting.get
+    site_title = setting.site_title
+
     {
-      site: 'IRC ログアーカイブ',
+      site: site_title,
       reverse: true,
       og: {
         url: request.url,
         title: :title,
-        site_name: 'IRC ログアーカイブ',
+        site_name: site_title,
         description: :description,
         locale: 'ja_JP'
       }
@@ -22,5 +25,24 @@ module ApplicationHelper
   # 自動でリンクを張る
   def linkify(s)
     Rinku.auto_link(h(s), :urls)
+  end
+
+  # Markdown ソースを HTML ソースに変換する
+  # @param [String] source Markdown ソース
+  # @return [String]
+  def markdown(source)
+    markdown = Redcarpet::Markdown.new(
+      Redcarpet::Render::HTML,
+      no_intra_emphasis: true,
+      tables: true,
+      fenced_code_blocks: true,
+      autolink: true,
+      disable_indented_code_blocks: true,
+      strikethrough: true,
+      underline: true,
+      highlight: true
+    )
+
+    markdown.render(source).html_safe
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,13 @@
+class Setting < ActiveRecord::Base
+  validates(
+    :site_title,
+    presence: true,
+    length: { maximum: 255 }
+  )
+
+  # アプリケーションの設定を取得する
+  # @return [Setting]
+  def self.get
+    first!
+  end
+end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="<%= root_path %>">IRC ログアーカイブ</a>
+      <a class="navbar-brand" href="<%= root_path %>"><%= site_title %></a>
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,7 +4,11 @@
   <div class="row">
     <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
       <div class="page-header">
-        <h1>irc.cre.jp ログアーカイブ</h1>
+        <h1><%= @setting.site_title %></h1>
+      </div>
+
+      <div class="text-on-homepage">
+        <%= markdown(@setting.text_on_homepage) %>
       </div>
 
       <!-- Navタブ -->

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
       <div class="page-header">
-        <h1><%= @setting.site_title %></h1>
+        <h1><%= site_title %></h1>
       </div>
 
       <div class="text-on-homepage">

--- a/db/migrate/20170329121959_create_settings.rb
+++ b/db/migrate/20170329121959_create_settings.rb
@@ -1,0 +1,12 @@
+class CreateSettings < ActiveRecord::Migration
+  def change
+    create_table :settings do |t|
+      # サイト名
+      t.string :site_title, null: false, default: 'IRC ログアーカイブ'
+      # ホームページに表示する文章
+      t.text :text_on_homepage, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170327111318) do
+ActiveRecord::Schema.define(version: 20170329121959) do
 
   create_table "channels", force: :cascade, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.string   "name",            limit: 255, default: "",   null: false
@@ -83,6 +83,13 @@ ActiveRecord::Schema.define(version: 20170327111318) do
   add_index "messages", ["nick"], name: "index_messages_on_nick", using: :btree
   add_index "messages", ["timestamp"], name: "index_messages_on_timestamp", using: :btree
   add_index "messages", ["type"], name: "index_messages_on_type", using: :btree
+
+  create_table "settings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
+    t.string   "site_title",       limit: 255,   default: "IRC ログアーカイブ", null: false
+    t.text     "text_on_homepage", limit: 65535,                         null: false
+    t.datetime "created_at",                                             null: false
+    t.datetime "updated_at",                                             null: false
+  end
 
   add_foreign_key "conversation_messages", "irc_users", name: "irc_user_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
-%w(irc_test irc_test2).each do |channel_name|
-  Channel.find_or_create_by(name: channel_name) do |channel|
-    channel.identifier = channel_name
-    channel.logging_enabled = true
-  end
+# 設定の初期値を設定する
+Settings.find_or_create_by(id: 1) do |settings|
+  # サイト名
+  settings.site_title = 'IRC ログアーカイブ'
+  # ホームページに表示する文章
+  settings.text_on_homepage = 'このサイトでは IRC ログを保管しています。'
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :setting do
+    site_title 'IRC ログアーカイブ'
+    text_on_homepage 'このサイトでは IRC ログを記録しています。'
+  end
+end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class SettingTest < ActiveSupport::TestCase
+  setup do
+    @setting = create(:setting)
+  end
+
+  test '有効である' do
+    assert(@setting.valid?)
+  end
+
+  test 'site_title は必須' do
+    @setting.site_title = ''
+    refute(@setting.valid?)
+  end
+
+  test 'site_title は空白のみではならない' do
+    @setting.site_title = ' ' * 10
+    refute(@setting.valid?)
+  end
+
+  test 'site_title は 255 文字以下' do
+    @setting.site_title = 'A' * 256
+    refute(@setting.valid?)
+  end
+end


### PR DESCRIPTION
#26「Rails: ページタイトルを設定ファイルで変更できるようにする」の途中です。

# 1. 設定（Setting）モデルの作成

OIAX社の「[アプリケーションの設定をデータベースで管理する](https://www.oiax.jp/rails/rails_exercises/quiz01.html)」の記事を参考にして、設定をデータベースに保存する方法で以下を保存できるようにしてみました。

* サイト名（site_title）
* ホームページのタイトル見出しの下に表示する文章（text_on_homepage）

# 2. 設定したサイト名等の値を画面に表示する

以下のようにホームページの上部の見出しと文章の部分で設定した値を表示するようにしました。タイトルの下の文章はMarkdownで書けるようにして、例えばリンクを張る等ができるようにしました。

----

![サイト名と文章が表示される](https://cloud.githubusercontent.com/assets/2551173/24536574/36e88d52-1616-11e7-8797-79963ef3634a.png)

# 追加した機能を試す際の手順

Gemの追加、モデルの追加があったので、以下のコマンドを実行します。

```bash
# Gemのインストール
bundle install
# データベースの更新
bin/rake db:migrate
# 設定の初期データの追加
bin/rake db:seed
```

# その他

* 現在はRailsのコンソール（`bin/rails console` で出る）でしか変更できませんが、今後、Redmineのように、ログイン後表示することができる設定画面を作り、管理者が設定を変更できるようにする予定です。
* データベースに設定を保存するようにし、その中でも列で設定項目を表す方法を採用した理由としては以下があります。
    * Railsの普通のやり方に沿っているので、型を決め、検証方法を書くのが楽。他の方法ではそれらをバグを入れないように自前で書く必要があって難しく、また車輪の再発明のように思えた（Railsの普通のやり方で実現できる）。
    * 設定項目はそれほど多くならなさそう。テーブルの列数制限の[1017個（InnoDBの場合）](https://dev.mysql.com/doc/refman/5.6/ja/innodb-restrictions.html)まではまず増えない。