### PR TITLE
自動リンクの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,8 @@ gem 'bootstrap3-datetimepicker-rails', '~> 4.17'
 gem 'redcarpet'
 
 # 自動リンク
-gem 'rinku'
+# スキーム付きのURLのみ有効にするために独自ブランチを使用する
+gem 'rinku', :git => 'https://github.com/cre-ne-jp/rinku.git', :branch => 'without-www'
 
 # ページネーション
 gem 'kaminari', github: 'amatsuda/kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,13 @@ GIT
       kaminari-core
     kaminari-core (0.1.0)
 
+GIT
+  remote: https://github.com/cre-ne-jp/rinku.git
+  revision: 083f90785f2470c11387ee728da93f800c5932a9
+  branch: without-www
+  specs:
+    rinku (2.0.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -218,7 +225,6 @@ GEM
     rdoc (4.2.2)
       json (~> 1.4)
     redcarpet (3.4.0)
-    rinku (2.0.2)
     ruby-progressbar (1.8.1)
     ruby_dep (1.4.0)
     sass (3.4.22)
@@ -304,7 +310,7 @@ DEPENDENCIES
   pry-rails
   rails (= 4.2.6)
   redcarpet
-  rinku
+  rinku!
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simple_calendar (~> 2.0)

--- a/app/controllers/messages/searches_controller.rb
+++ b/app/controllers/messages/searches_controller.rb
@@ -32,7 +32,7 @@ class Messages::SearchesController < ApplicationController
   def params_for_create
     result = params.
       require(:message_search).
-      permit(:query, :since, :until, channels: [])
+      permit(:query, :nick, :since, :until, channels: [])
 
     channels = result['channels']
     channels.select!(&:present?) if channels
@@ -41,6 +41,6 @@ class Messages::SearchesController < ApplicationController
   end
 
   def params_for_show
-    params.permit(:q, :channels, :since, :until, :page)
+    params.permit(:q, :nick, :channels, :since, :until, :page)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,8 +26,11 @@ module ApplicationHelper
   end
 
   # 自動でリンクを張る
+  #
+  # スキーム付きの部分のみにリンクが張られるように
+  # 独自のオプションを渡す。
   def linkify(s)
-    Rinku.auto_link(h(s), :urls)
+    Rinku.auto_link(h(s), :urls_without_www)
   end
 
   # Markdown ソースを HTML ソースに変換する

--- a/app/models/conversation_message.rb
+++ b/app/models/conversation_message.rb
@@ -2,6 +2,10 @@ class ConversationMessage < ActiveRecord::Base
   belongs_to :channel
   belongs_to :irc_user
 
+  scope :nick_search, ->(nick) {
+    where('MATCH(nick) AGAINST(? IN BOOLEAN MODE)', "*D+ #{nick}")
+  }
+
   scope :full_text_search, ->(query) {
     where('MATCH(message) AGAINST(? IN BOOLEAN MODE)', "*D+ #{query}")
   }

--- a/app/models/message_search.rb
+++ b/app/models/message_search.rb
@@ -9,6 +9,9 @@ class MessageSearch
   # 検索文字列
   # @return [String]
   attr_accessor :query
+  # ニックネーム
+  # @return [String]
+  attr_accessor :nick
   # チャンネル識別子
   #
   # パラメータ名の都合で名前がchannelsでも識別子を表すことに注意。
@@ -89,6 +92,7 @@ class MessageSearch
   def attributes
     {
       'query' => @query,
+      'nick' => @nick,
       'channels' => @channels,
       'since' => @since,
       'until' => @until,
@@ -101,6 +105,7 @@ class MessageSearch
   # @return [Hash] 指定したハッシュ
   def attributes=(hash)
     self.query = hash['query']
+    self.nick = hash['nick']
     self.channels = hash['channels']
     self.since = hash['since']
     self.until = hash['until']
@@ -114,6 +119,7 @@ class MessageSearch
   def attributes_for_result_page
     {
       'q' => @query,
+      'nick' => @nick,
       'channels' => @channels.join(' '),
       'since' => @since&.strftime('%F'),
       'until' => @until&.strftime('%F'),
@@ -126,6 +132,7 @@ class MessageSearch
   # @return [Hash] 指定したハッシュ
   def set_attributes_with_result_page_params(params)
     self.query = params['q']
+    self.nick = params['nick']
     self.channels = params['channels'].split(' ')
     self.since = params['since']
     self.until = params['until']
@@ -152,6 +159,10 @@ class MessageSearch
 
     if @until.present?
       messages = messages.where('timestamp <= ?', @until)
+    end
+
+    if @nick.present?
+      messages = messages.nick_search(@nick)
     end
 
     messages = messages.

--- a/app/models/message_search.rb
+++ b/app/models/message_search.rb
@@ -32,7 +32,7 @@ class MessageSearch
   # @return [Integer]
   attr_accessor :page
 
-  validates(:query, presence: true)
+  validates(:query_or_nick, presence: true)
   validates(
     :page,
     numericality: {
@@ -165,6 +165,10 @@ class MessageSearch
       messages = messages.nick_search(@nick)
     end
 
+    if @query.present?
+      messages = messages.full_text_search(@query)
+    end
+
     messages = messages.
       select('DATE(timestamp) AS date',
              :type,
@@ -174,7 +178,6 @@ class MessageSearch
              :timestamp,
              :nick,
              :message).
-      full_text_search(@query).
       order(timestamp: :desc).
       page(@page).
       includes(:channel)
@@ -188,6 +191,12 @@ class MessageSearch
   # ページ番号を正しくする
   def correct_page
     @page = 1 if !@page || @page < 1
+  end
+
+  # 検索文字列またはニックネームが存在するか
+  # @return [Boolean]
+  def query_or_nick
+    @query.presence || @nick.presence
   end
 
   # 開始日と終了日が共に指定されているときは、

--- a/app/views/messages/searches/show.html.erb
+++ b/app/views/messages/searches/show.html.erb
@@ -12,8 +12,10 @@
       <div class="search-conditions well">
         <h2>検索条件</h2>
         <ul>
-          <li>検索文字列：<%= @message_search.query %></li>
-          <% if @message_search.nick %>
+          <% if @message_search.query.present? %>
+            <li>検索文字列：<%= @message_search.query %></li>
+          <% end %>
+          <% if @message_search.nick.present? %>
             <li>ニックネーム：<%= @message_search.nick %></li>
           <% end %>
           <% unless @result.channels.empty? %>

--- a/app/views/messages/searches/show.html.erb
+++ b/app/views/messages/searches/show.html.erb
@@ -13,6 +13,9 @@
         <h2>検索条件</h2>
         <ul>
           <li>検索文字列：<%= @message_search.query %></li>
+          <% if @message_search.nick %>
+            <li>ニックネーム：<%= @message_search.nick %></li>
+          <% end %>
           <% unless @result.channels.empty? %>
             <li>チャンネル：<%= @result.channels.map(&:name_with_prefix).join(', ') %></li>
           <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -82,6 +82,11 @@
                 </div>
 
                 <div class="form-group">
+                  <%= f.label(:nick) %>
+                  <%= f.search_field(:nick, class: 'form-control') %>
+                </div>
+
+                <div class="form-group">
                   <%= f.label(:channels) %>
                   <%= f.select(:channels, channel_option_tags, {}, multiple: true, class: 'form-control') %>
                 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -78,12 +78,13 @@
               <%= form_for(@message_search, url: messages_search_path) do |f| %>
                 <div class="form-group">
                   <%= f.label(:query) %>
-                  <%= f.search_field(:query, class: 'form-control', required: true) %>
+                  <%= f.search_field(:query, class: 'form-control') %>
                 </div>
 
                 <div class="form-group">
                   <%= f.label(:nick) %>
                   <%= f.search_field(:nick, class: 'form-control') %>
+                  <p class="help-block">検索文字列またはニックネームが必須です。</p>
                 </div>
 
                 <div class="form-group">

--- a/config/locales/ja_activerecord.yml
+++ b/config/locales/ja_activerecord.yml
@@ -27,6 +27,7 @@ ja:
         date_type: 日付
       message_search:
         query: 検索文字列
+        nick: ニックネーム
         channels: チャンネル
         since: 開始日
         until: 終了日

--- a/config/locales/ja_activerecord.yml
+++ b/config/locales/ja_activerecord.yml
@@ -28,6 +28,7 @@ ja:
       message_search:
         query: 検索文字列
         nick: ニックネーム
+        query_or_nick: 検索文字列またはニックネーム
         channels: チャンネル
         since: 開始日
         until: 終了日

--- a/db/migrate/20170403224903_add_indices_to_conversation_messages.rb
+++ b/db/migrate/20170403224903_add_indices_to_conversation_messages.rb
@@ -1,0 +1,25 @@
+class AddIndicesToConversationMessages < ActiveRecord::Migration
+  reversible do |dir|
+    dir.up do
+      remove_index :conversation_messages, column: :nick
+
+      add_index :conversation_messages, :nick, type: :fulltext
+      add_index :conversation_messages, [:nick, :message], type: :fulltext
+      add_index :conversation_messages, [:channel_id, :timestamp]
+
+      execute('ALTER TABLE conversation_messages DISABLE KEYS')
+      execute('ALTER TABLE conversation_messages ENABLE KEYS')
+    end
+
+    dir.down do
+      add_index :conversation_messages, :nick
+
+      remove_index :conversation_messages, column: :nick
+      remove_index :conversation_messages, column: [:nick, :message]
+      remove_index :conversation_messages, column: [:channel_id, :timestamp]
+
+      execute('ALTER TABLE conversation_messages DISABLE KEYS')
+      execute('ALTER TABLE conversation_messages ENABLE KEYS')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170403105703) do
+ActiveRecord::Schema.define(version: 20170403224903) do
 
   create_table "channel_last_speeches", force: :cascade, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "channel_id",              limit: 4
@@ -45,13 +45,15 @@ ActiveRecord::Schema.define(version: 20170403105703) do
     t.string   "type",        limit: 255
   end
 
+  add_index "conversation_messages", ["channel_id", "timestamp"], name: "index_conversation_messages_on_channel_id_and_timestamp", using: :btree
   add_index "conversation_messages", ["channel_id"], name: "index_conversation_messages_on_channel_id", using: :btree
   add_index "conversation_messages", ["id", "channel_id", "timestamp"], name: "index_conversation_messages_on_id_and_channel_id_and_timestamp", using: :btree
   add_index "conversation_messages", ["id", "channel_id"], name: "index_conversation_messages_on_id_and_channel_id", using: :btree
   add_index "conversation_messages", ["id", "timestamp"], name: "index_conversation_messages_on_id_and_timestamp", using: :btree
   add_index "conversation_messages", ["irc_user_id"], name: "index_conversation_messages_on_irc_user_id", using: :btree
   add_index "conversation_messages", ["message"], name: "index_conversation_messages_on_message", type: :fulltext
-  add_index "conversation_messages", ["nick"], name: "index_conversation_messages_on_nick", using: :btree
+  add_index "conversation_messages", ["nick", "message"], name: "index_conversation_messages_on_nick_and_message", type: :fulltext
+  add_index "conversation_messages", ["nick"], name: "index_conversation_messages_on_nick", type: :fulltext
   add_index "conversation_messages", ["timestamp"], name: "index_conversation_messages_on_timestamp", using: :btree
   add_index "conversation_messages", ["type"], name: "index_conversation_messages_on_type", using: :btree
 

--- a/test/factories/message_searches.rb
+++ b/test/factories/message_searches.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :message_search do
     query 'test'
+    nick 'someone'
     channels { [create(:channel).identifier] }
     since Date.new(2001, 2, 3)
     add_attribute(:until) { nil }

--- a/test/models/message_search_test.rb
+++ b/test/models/message_search_test.rb
@@ -36,6 +36,7 @@ class MessageSearchTest < ActiveSupport::TestCase
     attributes = @search.attributes
 
     assert_equal(@search.query, attributes.fetch('query'), 'query')
+    assert_equal(@search.nick, attributes.fetch('nick'), 'nick')
     assert_equal(@search.channels, attributes.fetch('channels'), 'channels')
     assert_equal(@search.since, attributes.fetch('since'), 'since')
     assert_equal(@search.until, attributes.fetch('until'), 'until')
@@ -49,6 +50,7 @@ class MessageSearchTest < ActiveSupport::TestCase
 
     attributes = {
       'query' => 'test',
+      'nick' => 'foo',
       'channels' => channel_identifiers,
       'since' => Date.new(2000, 1, 23),
       'until' => Date.new(2001, 12, 31),
@@ -58,6 +60,7 @@ class MessageSearchTest < ActiveSupport::TestCase
     @search.attributes = attributes
 
     assert_equal(attributes['query'], @search.query, 'query')
+    assert_equal(attributes['nick'], @search.nick, 'nick')
     assert_equal(attributes['channels'], @search.channels, 'channels')
     assert_equal(attributes['since'], @search.since, 'since')
     assert_equal(attributes['until'], @search.until, 'until')
@@ -68,6 +71,7 @@ class MessageSearchTest < ActiveSupport::TestCase
     attributes = @search.attributes_for_result_page
 
     assert_equal(@search.query, attributes.fetch('q'), 'query')
+    assert_equal(@search.nick, attributes.fetch('nick'), 'nick')
     assert_equal(@search.channels.join(' '), attributes.fetch('channels'), 'channels')
     assert_equal(@search.since&.strftime('%F'), attributes.fetch('since'), 'since')
     assert_equal(@search.until&.strftime('%F'), attributes.fetch('until'), 'until')
@@ -80,6 +84,7 @@ class MessageSearchTest < ActiveSupport::TestCase
     channel_identifiers = channels.map(&:identifier)
     attributes = {
       'q' => 'test',
+      'nick' => 'foo',
       'channels' => channel_identifiers.join(' '),
       'since' => '2000-01-23',
       'until' => '2001-12-31',
@@ -89,6 +94,7 @@ class MessageSearchTest < ActiveSupport::TestCase
     @search.set_attributes_with_result_page_params(attributes)
 
     assert_equal(attributes['q'], @search.query, 'query')
+    assert_equal(attributes['nick'], @search.nick, 'nick')
     assert_equal(channel_identifiers, @search.channels, 'channel')
     assert_equal(attributes['since'].to_date, @search.since, 'since')
     assert_equal(attributes['until'].to_date, @search.until, 'until')

--- a/test/models/message_search_test.rb
+++ b/test/models/message_search_test.rb
@@ -9,14 +9,24 @@ class MessageSearchTest < ActiveSupport::TestCase
     assert(@search.valid?)
   end
 
-  test 'query は必須' do
-    @search.query = nil
+  test 'query または nick は必須' do
+    @search.query = @search.nick = nil
     refute(@search.valid?)
   end
 
-  test 'query は空白のみではならない' do
-    @search.query = ' ' * 10
+  test 'query および nick が空白のみではならない' do
+    @search.query = @search.nick = ' ' * 10
     refute(@search.valid?)
+  end
+
+  test 'query のみは有効' do
+    @search.nick = ''
+    assert(@search.valid?)
+  end
+
+  test 'nick のみは有効' do
+    @search.query = ''
+    assert(@search.valid?)
   end
 
   test 'since と until が共に存在する場合、until は since 以上' do


### PR DESCRIPTION
メッセージ一覧において、スキームのない「www.」から始まる部分がリンクになってしまう問題を修正します。

これはRinku gemに「www.」から始まる部分をリンクに変換しないようにするオプションがないために発生します。そこで、[Rinku gemの独自ブランチを作り、その機能を無効にするオプションを追加しました](https://github.com/vmg/rinku/compare/master...cre-ne-jp:without-www?expand=1)。log-archiverではそのブランチを使うようにしています。