### PR TITLE
メッセージのフラグメント識別子をクラスによって変える

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,8 @@ module ApplicationHelper
 
   # チャンネルの最終発言日時へのリンクを返す
   def last_speech_timestamp_link(channel)
-    if last_speech = channel.last_speech
+    last_speech = channel.last_speech
+    if last_speech
       browse_day = ChannelBrowse::Day.new(
         channel: channel, date: last_speech.timestamp.to_date
       )
@@ -62,7 +63,7 @@ module ApplicationHelper
       link_to(
         last_speech.timestamp.strftime('%F %T'),
         channels_day_path(
-          browse_day.params_for_url.merge({ anchor: last_speech.id })
+          browse_day.params_for_url.merge({ anchor: last_speech.fragment_id })
         )
       )
     else

--- a/app/models/conversation_message.rb
+++ b/app/models/conversation_message.rb
@@ -2,6 +2,13 @@ class ConversationMessage < ActiveRecord::Base
   belongs_to :channel
   belongs_to :irc_user
 
+  validates :channel, presence: true
+  validates :timestamp, presence: true
+  validates :nick,
+    presence: true,
+    length: { maximum: 64 }
+  validates :message, length: { maximum: 512 }
+
   scope :nick_search, ->(nick) {
     where('MATCH(nick) AGAINST(? IN BOOLEAN MODE)', "*D+ #{nick}")
   }
@@ -9,4 +16,10 @@ class ConversationMessage < ActiveRecord::Base
   scope :full_text_search, ->(query) {
     where('MATCH(message) AGAINST(? IN BOOLEAN MODE)', "*D+ #{query}")
   }
+
+  # URLのフラグメント識別子を返す
+  # @return [String]
+  def fragment_id
+    "c#{id}"
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,4 +8,10 @@ class Message < ActiveRecord::Base
     presence: true,
     length: { maximum: 64 }
   validates :message, length: { maximum: 512 }
+
+  # URLのフラグメント識別子を返す
+  # @return [String]
+  def fragment_id
+    "m#{id}"
+  end
 end

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,4 +1,4 @@
-<% anchor = m.id %>
+<% anchor = m.fragment_id %>
 <% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
 <tr class="message-type-<%= m.type.downcase %>">
   <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), channels_day_path(browse_day.params_for_url.merge({ anchor: anchor })), id: anchor) %></td>

--- a/test/factories/conversation_messages.rb
+++ b/test/factories/conversation_messages.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :conversation_message do
-    channel nil
-    irc_user nil
+    channel
+    irc_user
     type 'Privmsg'
     timestamp "2016-11-29 00:42:49"
-    nick "MyString"
-    message "MyText"
+    nick 'rgrb'
+    message 'Hello world'
 
     # タイムスタンプは 100 -> 400 -> 200 の順に新しい
     factory :message_100 do

--- a/test/factories/messages.rb
+++ b/test/factories/messages.rb
@@ -2,10 +2,10 @@ FactoryGirl.define do
   factory :message do
     channel
     irc_user
-    type ""
+    type 'Part'
     timestamp "2016-04-01 12:34:56"
-    nick "rgrb"
-    message nil
+    nick 'rgrb'
+    message 'Bye!'
     target nil
   end
 end

--- a/test/models/conversation_message_test.rb
+++ b/test/models/conversation_message_test.rb
@@ -1,7 +1,51 @@
 require 'test_helper'
 
 class ConversationMessageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @message = create(:conversation_message)
+  end
+
+  test '有効である' do
+    assert(@message.valid?)
+  end
+
+  test 'channel は必須' do
+    @message.channel = nil
+    refute(@message.valid?)
+  end
+
+  test 'timestamp は必須' do
+    @message.timestamp = nil
+    refute(@message.valid?)
+  end
+
+  test 'nick は必須' do
+    @message.nick = nil
+    refute(@message.valid?)
+  end
+
+  test 'nick は空白のみではならない' do
+    @message.nick = ' ' * 10
+    refute(@message.valid?)
+  end
+
+  test 'nick は 64 文字以内' do
+    @message.nick = 'a' * 64
+    assert(@message.valid?, '64 文字は OK')
+
+    @message.nick = 'a' * 65
+    refute(@message.valid?, '65 文字は NG')
+  end
+
+  test 'message は 512 文字以内' do
+    @message.message = 'a' * 512
+    assert(@message.valid?, '512 文字は OK')
+
+    @message.message = 'a' * 513
+    refute(@message.valid?, '513 文字は NG')
+  end
+
+  test 'fragment_id が正しい' do
+    assert_equal("c#{@message.id}", @message.fragment_id)
+  end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -44,4 +44,8 @@ class MessageTest < ActiveSupport::TestCase
     @message.message = 'a' * 513
     refute(@message.valid?, '513 文字は NG')
   end
+
+  test 'fragment_id が正しい' do
+    assert_equal("m#{@message.id}", @message.fragment_id)
+  end
 end


### PR DESCRIPTION
メッセージのフラグメント識別子（HTMLのidで指定するもの）が衝突するのを防ぐ。MessageとConversationMessageで番号が同じになる場合があるため。