### PR TITLE
ChannelBrowse::Dayのリファクタリング

### DIFF
--- a/app/controllers/browses_controller.rb
+++ b/app/controllers/browses_controller.rb
@@ -5,7 +5,7 @@ class BrowsesController < ApplicationController
 
     if @channel_browse.valid?
       browse_day = @channel_browse.to_channel_browse_day
-      redirect_to(channels_day_path(browse_day.params_for_url))
+      redirect_to(browse_day.path)
     else
       @invalid_model = :channel_browse
       render 'welcome/index'

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -32,10 +32,6 @@ class Channels::DaysController < ApplicationController
     @day = params[:day].to_i
     @date = Date.new(@year, @month, @day)
 
-    @browse_day = ChannelBrowse::Day.new(channel: @channel, date: @date)
-    @browse_prev_day = ChannelBrowse::Day.new(channel: @channel, date: @date.prev_day)
-    @browse_next_day = ChannelBrowse::Day.new(channel: @channel, date: @date.next_day)
-
     @browse_year = ChannelBrowse::Year.new(channel: @channel, year: @date.year)
     @browse_month = ChannelBrowse::Month.new(channel: @channel, year: @date.year, month: @date.month)
 
@@ -54,6 +50,17 @@ class Channels::DaysController < ApplicationController
       to_a
 
     @list_style = (params[:style] == 'raw') ? :raw : :normal
+
+    @browse_day = ChannelBrowse::Day.new(
+      channel: @channel, date: @date, style: @list_style
+    )
+    @browse_prev_day = ChannelBrowse::Day.new(
+      channel: @channel, date: @date.prev_day, style: @list_style
+    )
+    @browse_next_day = ChannelBrowse::Day.new(
+      channel: @channel, date: @date.next_day, style: @list_style
+    )
+
     whole_messages =
       if @list_style == :raw
         HourSeparator.for_day_browse(@date) + messages + @conversation_messages
@@ -64,11 +71,8 @@ class Channels::DaysController < ApplicationController
     # タイムスタンプによるソート
     # 安定ソートとなるようにカウンタを用意する
     i = 0
-    @sorted_messages = whole_messages.
-      sort_by { |m| [m.timestamp, i += 1] }
+    @sorted_messages = whole_messages.sort_by { |m| [m.timestamp, i += 1] }
 
     @message_dates = MessageDate.where(channel: @channel)
-
-    @day_link_params = (@list_style == :raw) ? { style: 'raw' } : {}
   end
 end

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -24,9 +24,7 @@ class Channels::DaysController < ApplicationController
   def show
     target_channels, @other_channels = Channel.
       order_for_list.
-      partition { |channel|
-        channel.identifier == params[:identifier]
-      }
+      partition { |channel| channel.identifier == params[:id] }
     @channel = target_channels.first
 
     @year = params[:year].to_i

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,12 +60,8 @@ module ApplicationHelper
         channel: channel, date: last_speech.timestamp.to_date
       )
 
-      link_to(
-        last_speech.timestamp.strftime('%F %T'),
-        channels_day_path(
-          browse_day.params_for_url.merge({ anchor: last_speech.fragment_id })
-        )
-      )
+      link_to(last_speech.timestamp.strftime('%F %T'),
+              browse_day.path(anchor: last_speech.fragment_id))
     else
       '発言なし'
     end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -92,6 +92,13 @@ class Channel < ActiveRecord::Base
       }
   end
 
+  # Cinch::Message から該当するチャンネルを検索する
+  # @param [Cinch::Message] m IRC メッセージ
+  # @return [Channel, nil]
+  def self.from_cinch_message(m)
+    find_by(name: m.channel.name[1..-1])
+  end
+
   # 接頭辞付きのチャンネル名を返す
   # @return [String]
   def name_with_prefix

--- a/app/models/channel_browse.rb
+++ b/app/models/channel_browse.rb
@@ -75,19 +75,15 @@ class ChannelBrowse
   def to_channel_browse_day
     return nil unless valid?
 
-    date_value =
-      case date_type
-      when :today
-        Time.now.to_date
-      when :yesterday
-        Time.now.to_date.prev_day
-      when :specify
-        @date
-      end
+    channel = Channel.friendly.find(@channel)
 
-    ChannelBrowse::Day.new(
-      channel: Channel.friendly.find(@channel),
-      date: date_value
-    )
+    case date_type
+    when :today
+      ChannelBrowse::Day.today(channel)
+    when :yesterday
+      ChannelBrowse::Day.yesterday(channel)
+    when :specify
+      ChannelBrowse::Day.new(channel: channel, date: @date)
+    end
   end
 end

--- a/app/models/channel_browse/day.rb
+++ b/app/models/channel_browse/day.rb
@@ -1,6 +1,9 @@
 # チャンネルのある日付（年月日）の閲覧を表すクラス
 class ChannelBrowse::Day
   include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
+
+  extend SimpleEnum::Attribute
 
   # チャンネル
   # @return [Channel]
@@ -8,9 +11,21 @@ class ChannelBrowse::Day
   # 日付
   # @return [Date]
   attr_accessor :date
+  # 表示のスタイル
+  #
+  # * normal: 通常
+  # * raw: 生ログ
+  attr_accessor :style_cd
+  as_enum(:style, %i{normal raw}, prefix: :is_style)
 
   validates(:channel, presence: true)
   validates(:date, presence: true)
+  validates(:style, presence: true)
+
+  def initialize(*)
+    self.style = :normal
+    super
+  end
 
   # 日付を設定する
   #
@@ -30,11 +45,14 @@ class ChannelBrowse::Day
   def params_for_url
     return nil unless valid?
 
-    {
+    params = {
       identifier: @channel&.identifier,
       year: @date.year.to_s,
       month: '%02d' % @date.month,
       day: '%02d' % @date.day
     }
+    style_params = (style == :normal) ? {} : { style: style.to_s }
+
+    params.merge(style_params)
   end
 end

--- a/app/models/channel_browse/day.rb
+++ b/app/models/channel_browse/day.rb
@@ -72,26 +72,28 @@ class ChannelBrowse::Day
   end
 
   # ログ閲覧ページのパスを返す
+  # @param [Hash] params 追加のパラメータ
   # @return [String] ログ閲覧ページのパス
   # @return [nil] 属性が無効な場合
-  def path
+  def path(params = {})
     return nil unless valid?
 
     Rails.application.routes.url_helpers.channels_day_path(
-      @channel, params_for_url
+      @channel, params_for_url.merge(params)
     )
   end
 
   # ログ閲覧ページの URL を返す
   # @param [String] host ホスト名。スキーム付きでもよい
+  # @param [Hash] params 追加のパラメータ
   # @return [String] ログ閲覧ページの URL
   # @return [nil] 属性が無効な場合
-  def url(host)
+  def url(host, params = {})
     return nil unless valid?
 
     Rails.application.routes.url_helpers.channels_day_url(
       @channel,
-      params_for_url.merge({ host: host })
+      params_for_url.merge(params).merge({ host: host })
     )
   end
 end

--- a/app/models/channel_browse/day.rb
+++ b/app/models/channel_browse/day.rb
@@ -62,7 +62,6 @@ class ChannelBrowse::Day
     return nil unless valid?
 
     params = {
-      identifier: @channel&.identifier,
       year: @date.year.to_s,
       month: '%02d' % @date.month,
       day: '%02d' % @date.day
@@ -70,5 +69,29 @@ class ChannelBrowse::Day
     style_params = (style == :normal) ? {} : { style: style.to_s }
 
     params.merge(style_params)
+  end
+
+  # ログ閲覧ページのパスを返す
+  # @return [String] ログ閲覧ページのパス
+  # @return [nil] 属性が無効な場合
+  def path
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_day_path(
+      @channel, params_for_url
+    )
+  end
+
+  # ログ閲覧ページの URL を返す
+  # @param [String] host ホスト名。スキーム付きでもよい
+  # @return [String] ログ閲覧ページの URL
+  # @return [nil] 属性が無効な場合
+  def url(host)
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_day_url(
+      @channel,
+      params_for_url.merge({ host: host })
+    )
   end
 end

--- a/app/models/channel_browse/day.rb
+++ b/app/models/channel_browse/day.rb
@@ -27,6 +27,22 @@ class ChannelBrowse::Day
     super
   end
 
+  # 今日のログの閲覧を返す
+  # @param [Channel] channel チャンネル
+  # @param [Symbol] style 表示のスタイル
+  # @return [ChannelBrowse::Day]
+  def self.today(channel, style: :normal)
+    new(channel: channel, date: Time.current.to_date, style: style)
+  end
+
+  # 昨日のログの閲覧を返す
+  # @param [Channel] channel チャンネル
+  # @param [Symbol] style 表示のスタイル
+  # @return [ChannelBrowse::Day]
+  def self.yesterday(channel, style: :normal)
+    new(channel: channel, date: Time.current.to_date.prev_day, style: style)
+  end
+
   # 日付を設定する
   #
   # value を日付に変換できないときは nil になる。

--- a/app/views/channels/days/index.html.erb
+++ b/app/views/channels/days/index.html.erb
@@ -22,7 +22,7 @@
           <ul>
             <% @dates.each do |date| %>
               <% browse_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
-              <li><%= link_to(date.strftime('%F'), channels_day_path(browse_day.params_for_url)) %>（<%= @speech_count[date] || 0 %> 発言）</li>
+              <li><%= link_to(date.strftime('%F'), browse_day.path) %>（<%= @speech_count[date] || 0 %> 発言）</li>
             <% end %>
           </ul>
         </div>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -54,16 +54,16 @@
 
             <div class="row">
               <div class="col-xs-6">
-                <p><%= link_to(fa_icon('chevron-left', text: '前日'), channels_day_path(@browse_prev_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p><%= link_to(fa_icon('chevron-left', text: '前日'), @browse_prev_day.path, class: 'btn btn-primary btn-sm') %></p>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), @browse_next_day.path, class: 'btn btn-primary btn-sm') %></p>
               </div>
             </div>
 
             <ul class="nav nav-tabs">
-              <li role="presentation" class="<%= nav_tab_class(@list_style == :normal) %>"><%= link_to('通常表示', (@list_style == :normal) ? '#' : channels_day_path(@browse_day.params_for_url)) %></a></li>
-              <li role="presentation" class="<%= nav_tab_class(@list_style == :raw) %>"><%= link_to('生ログ', (@list_style == :raw) ? '#' : channels_day_path(@browse_day.params_for_url.merge(style: :raw))) %></a></li>
+              <li role="presentation" class="<%= nav_tab_class(@list_style == :normal) %>"><%= link_to('通常表示', (@list_style == :normal) ? '#' : @browse_day.path) %></a></li>
+              <li role="presentation" class="<%= nav_tab_class(@list_style == :raw) %>"><%= link_to('生ログ', (@list_style == :raw) ? '#' : @browse_day.path) %></a></li>
             </ul>
 
             <% if @list_style == :raw %>
@@ -78,10 +78,10 @@
 
             <div class="row">
               <div class="col-xs-6">
-                <p><%= link_to(fa_icon('chevron-left', text: '前日'), channels_day_path(@browse_prev_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p><%= link_to(fa_icon('chevron-left', text: '前日'), @browse_prev_day.path, class: 'btn btn-primary btn-sm') %></p>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), @browse_next_day.path, class: 'btn btn-primary btn-sm') %></p>
               </div>
             </div>
           </article>
@@ -97,7 +97,7 @@
               <%= date.day %>
             <% else %>
               <% browse_other_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
-              <%= link_to(date.day, channels_day_path(browse_other_day.params_for_url.merge(@day_link_params))) %>
+              <%= link_to(date.day, browse_other_day.path) %>
             <% end %>
           <% end %>
         </div>
@@ -110,8 +110,8 @@
         <div class="panel-body">
           <ul class="list-unstyled other-channel-list">
             <% @other_channels.each do |channel| %>
-              <% browse_other = ChannelBrowse::Day.new(channel: channel, date: @date) %>
-              <li><%= link_to(channel.name_with_prefix, channels_day_path(browse_other.params_for_url.merge(@day_link_params))) %></li>
+              <% browse_other_channel = ChannelBrowse::Day.new(channel: channel, date: @date) %>
+              <li><%= link_to(channel.name_with_prefix, browse_other_channel.path) %></li>
             <% end %>
           </ul>
         </div>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,7 +1,7 @@
 <% anchor = m.fragment_id %>
 <% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
 <tr class="message message-type-<%= m.type.downcase %>">
-  <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), channels_day_path(browse_day.params_for_url.merge({ anchor: anchor })), id: anchor) %></td>
+  <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor), id: anchor) %></td>
   <% if show_channel %>
     <td class="message-channel"><%= link_to(m.channel.name_with_prefix, channels_path(m.channel)) %></td>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resource :browse, only: %i(create)
 
   namespace :channels do
-    get ':identifier/:year/:month/:day', to: 'days#show', as: 'day',
+    get ':id/:year/:month/:day', to: 'days#show', as: 'day',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/, day: /0[1-9]|[12][0-9]|3[01]/
     get ':identifier/:year/:month', to: 'days#index', as: 'days',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/

--- a/test/factories/channel_browse/days.rb
+++ b/test/factories/channel_browse/days.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :channel_browse_day, class: ChannelBrowse::Day do
     channel
     date Date.new(2017, 1, 23)
+    style :normal
   end
 end

--- a/test/models/channel_browse/day_test.rb
+++ b/test/models/channel_browse/day_test.rb
@@ -26,11 +26,6 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
     refute(@day.valid?)
   end
 
-  test 'params_for_url: identifier が正しい' do
-    params = @day.params_for_url
-    assert_equal(@day.channel.identifier, params.fetch(:identifier))
-  end
-
   test 'params_for_url: 日付が正しい' do
     params = @day.params_for_url
 
@@ -69,5 +64,43 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
       assert_equal(@now.to_date.prev_day, browse_day.date, '日付が正しい')
       assert_equal(:raw, browse_day.style, '表示のスタイルが正しい')
     end
+  end
+
+  test 'path: ログ閲覧ページのパスが正しい' do
+    @day.style = :normal
+    @day.date = @now.to_date
+
+    assert_equal('/channels/irc_test/2017/04/01', @day.path)
+  end
+
+  test 'path: 生ログ閲覧ページのパスが正しい' do
+    @day.style = :raw
+    @day.date = @now.to_date
+
+    assert_equal('/channels/irc_test/2017/04/01?style=raw', @day.path)
+  end
+
+  test 'url: ログ閲覧ページの URL が正しい（スキーム付き）' do
+    @day.style = :normal
+    @day.date = @now.to_date
+
+    assert_equal('https://log.example.net/channels/irc_test/2017/04/01',
+                 @day.url('https://log.example.net'))
+  end
+
+  test 'url: ログ閲覧ページの URL が正しい（スキームなし）' do
+    @day.style = :normal
+    @day.date = @now.to_date
+
+    assert_equal('http://log.example.net/channels/irc_test/2017/04/01',
+                 @day.url('log.example.net'))
+  end
+
+  test 'url: 生ログ閲覧ページの URL が正しい' do
+    @day.style = :raw
+    @day.date = @now.to_date
+
+    assert_equal('https://log.example.net/channels/irc_test/2017/04/01?style=raw',
+                 @day.url('https://log.example.net'))
   end
 end

--- a/test/models/channel_browse/day_test.rb
+++ b/test/models/channel_browse/day_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class ChannelBrowse::DayTest < ActiveSupport::TestCase
   setup do
+    @channel = create(:channel)
     @day = build(:channel_browse_day)
+    @now = Time.zone.local(2017, 4, 1, 12, 34, 56)
   end
 
   test '有効である' do
@@ -47,5 +49,25 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
 
     params = @day.params_for_url
     assert_equal('raw', params.fetch(:style))
+  end
+
+  test 'today で今日のログの閲覧が返る' do
+    travel_to(@now) do
+      browse_day = ChannelBrowse::Day.today(@channel, style: :raw)
+
+      assert_equal(@channel, browse_day.channel, 'チャンネルが正しい')
+      assert_equal(@now.to_date, browse_day.date, '日付が正しい')
+      assert_equal(:raw, browse_day.style, '表示のスタイルが正しい')
+    end
+  end
+
+  test 'yesterday で昨日のログの閲覧が返る' do
+    travel_to(@now) do
+      browse_day = ChannelBrowse::Day.yesterday(@channel, style: :raw)
+
+      assert_equal(@channel, browse_day.channel, 'チャンネルが正しい')
+      assert_equal(@now.to_date.prev_day, browse_day.date, '日付が正しい')
+      assert_equal(:raw, browse_day.style, '表示のスタイルが正しい')
+    end
   end
 end

--- a/test/models/channel_browse/day_test.rb
+++ b/test/models/channel_browse/day_test.rb
@@ -19,12 +19,33 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
     refute(@day.valid?)
   end
 
-  test 'params_for_url の結果が正しい' do
+  test 'style は必須' do
+    @day.style = nil
+    refute(@day.valid?)
+  end
+
+  test 'params_for_url: identifier が正しい' do
+    params = @day.params_for_url
+    assert_equal(@day.channel.identifier, params.fetch(:identifier))
+  end
+
+  test 'params_for_url: 日付が正しい' do
     params = @day.params_for_url
 
-    assert_equal(@day.channel.identifier, params.fetch(:identifier), 'identifier')
     assert_equal(@day.date.year.to_s, params.fetch(:year), 'year')
     assert_equal('%02d' % @day.date.month, params.fetch(:month), 'month')
     assert_equal('%02d' % @day.date.day, params.fetch(:day), 'day')
+  end
+
+  test 'params_for_url: 通常のスタイルのとき :style が存在しない' do
+    @day.style = :normal
+    refute(@day.params_for_url.include?(:style))
+  end
+
+  test 'params_for_url: 生ログのとき :style が raw になる' do
+    @day.style = :raw
+
+    params = @day.params_for_url
+    assert_equal('raw', params.fetch(:style))
   end
 end

--- a/test/models/channel_browse/day_test.rb
+++ b/test/models/channel_browse/day_test.rb
@@ -80,6 +80,22 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
     assert_equal('/channels/irc_test/2017/04/01?style=raw', @day.path)
   end
 
+  test 'path: フラグメント識別子を指定することができる' do
+    @day.style = :normal
+    @day.date = @now.to_date
+
+    assert_equal('/channels/irc_test/2017/04/01#12345',
+                 @day.path(anchor: '12345'))
+  end
+
+  test 'path: 生ログ閲覧ページでフラグメント識別子を指定することができる' do
+    @day.style = :raw
+    @day.date = @now.to_date
+
+    assert_equal('/channels/irc_test/2017/04/01?style=raw#12345',
+                 @day.path(anchor: '12345'))
+  end
+
   test 'url: ログ閲覧ページの URL が正しい（スキーム付き）' do
     @day.style = :normal
     @day.date = @now.to_date
@@ -102,5 +118,21 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
 
     assert_equal('https://log.example.net/channels/irc_test/2017/04/01?style=raw',
                  @day.url('https://log.example.net'))
+  end
+
+  test 'url: フラグメント識別子を指定することができる' do
+    @day.style = :normal
+    @day.date = @now.to_date
+
+    assert_equal('https://log.example.net/channels/irc_test/2017/04/01#12345',
+                 @day.url('https://log.example.net', anchor: '12345'))
+  end
+
+  test 'url: 生ログ閲覧ページでフラグメント識別子を指定することができる' do
+    @day.style = :raw
+    @day.date = @now.to_date
+
+    assert_equal('https://log.example.net/channels/irc_test/2017/04/01?style=raw#12345',
+                 @day.url('https://log.example.net', anchor: '12345'))
   end
 end

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -95,4 +95,18 @@ class ChannelTest < ActiveSupport::TestCase
     expected = [100, 400, 200, 300, 500].map { |id| "channel_#{id}" }
     assert_equal(expected, Channel.for_channels_index.map(&:identifier))
   end
+
+  test 'from_cinch_message: 該当するチャンネルが返る' do
+    cinch_channel = Minitest::Mock.new.expect(:name, '#irc_test')
+    cinch_message = Minitest::Mock.new.expect(:channel, cinch_channel)
+
+    assert_equal(@channel, Channel.from_cinch_message(cinch_message))
+  end
+
+  test 'from_cinch_message: 登録されていないチャンネル名が指定された場合 nil が返る' do
+    cinch_channel = Minitest::Mock.new.expect(:name, '#not_registered')
+    cinch_message = Minitest::Mock.new.expect(:channel, cinch_channel)
+
+    assert_nil(Channel.from_cinch_message(cinch_message))
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+require 'minitest/mock'
+
 require 'simplecov'
 # カバレッジ測定開始
 SimpleCov.start do


### PR DESCRIPTION
UserInterfaceプラグインでのログURLの発言内容と閲覧部ともに同じURLを作れるように、1日分のログの閲覧を表すChannelBrowse::Dayモデルの機能を充実させました。プラグインでは特に、チャンネルと日付を指定して作ったChannelBrowse::Dayインスタンスに対して呼べる `ChannelBrowse::Day#url(host)` メソッドを使うことになると思います。

また、ChannelモデルにCinch::Messageインスタンスから検索するメソッドを追加したことで、その処理が書きやすくなりました。

# 使用例

```ruby
HOST = 'http://log.example.net'

# Cinch::Messageインスタンス m からチャンネルを検索する
channel = Channel.from_cinch_message(m)
if channel
  browse_today = ChannelBrowse::Day.today(channel)
  send_and_record(m, "今日のログ: #{browse_today.url(HOST)}")
end
```