### PR TITLE
すべてのプラグインでAtheme Servicesにログインしないようにする

### DIFF
--- a/lib/ircs/plugins/base.rb
+++ b/lib/ircs/plugins/base.rb
@@ -1,7 +1,6 @@
 # vim: fileencoding=utf-8
 
 require 'cinch'
-require_relative 'ircserv'
 
 module LogArchiver
   module Plugin
@@ -17,20 +16,6 @@ module LogArchiver
 
         @logger = config[:logger]
         @authentication_server = config[:authentication_server]
-
-        begin
-          @ircserv = IrcServ.new(
-            config[:authentication_server]['XMLRPC'],
-            config[:authentication_server]['Account']['Nick'],
-            config[:authentication_server]['Account']['Pass']
-          )
-        rescue XMLRPC::FaultException => e
-          @logger.error('認証サーバにログインできませんでした')
-          @logger.error("Code: #{e.faultCode}, Message: #{e.faultString}")
-          @ircserv = nil
-        rescue => e
-          @ircserv = nil
-        end
       end
 
       # IRC へ発言し、データベースに保存する


### PR DESCRIPTION
fixes #67

現時点ではIrcServを使ってAtheme Servicesにログインする必要があるプラグインがないため、一旦元に戻します。

再実装する場合にはコミット 03bd81abd057f3546591ea08d78a4beaf52886a5 を参考にするようにします。