### PR TITLE
月や日の一覧でも前・次のリンクを表示する

### DIFF
--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -4,8 +4,7 @@ class Channels::DaysController < ApplicationController
     @year = params[:year].to_i
     @month = params[:month].to_i
 
-    @browse_year = ChannelBrowse::Year.new(channel: @channel,
-                                           year: @year)
+    @browse_year = ChannelBrowse::Year.new(channel: @channel, year: @year)
 
     browse_month = ChannelBrowse::Month.new(channel: @channel,
                                             year: @year,

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -1,6 +1,6 @@
 class Channels::DaysController < ApplicationController
   def index
-    @channel = Channel.find_by(identifier: params[:identifier])
+    @channel = Channel.friendly.find(params[:id])
     @year = params[:year].to_i
     @month = params[:month].to_i
 

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -4,6 +4,9 @@ class Channels::DaysController < ApplicationController
     @year = params[:year].to_i
     @month = params[:month].to_i
 
+    @browse_year = ChannelBrowse::Year.new(channel: @channel,
+                                           year: @year)
+
     browse_month = ChannelBrowse::Month.new(channel: @channel,
                                             year: @year,
                                             month: @month)

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -4,6 +4,12 @@ class Channels::DaysController < ApplicationController
     @year = params[:year].to_i
     @month = params[:month].to_i
 
+    browse_month = ChannelBrowse::Month.new(channel: @channel,
+                                            year: @year,
+                                            month: @month)
+    @browse_prev_month = browse_month.prev_month
+    @browse_next_month = browse_month.next_month
+
     start_date = Date.new(@year, @month, 1)
     date_range = start_date...(start_date.next_month)
     @dates = MessageDate.

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -49,20 +49,20 @@ class Channels::DaysController < ApplicationController
       order(:timestamp, :id).
       to_a
 
-    @list_style = (params[:style] == 'raw') ? :raw : :normal
+    @browse_day_normal = ChannelBrowse::Day.new(
+      channel: @channel, date: @date, style: :normal
+    )
+    @browse_day_raw = ChannelBrowse::Day.new(
+      channel: @channel, date: @date, style: :raw
+    )
 
-    @browse_day = ChannelBrowse::Day.new(
-      channel: @channel, date: @date, style: @list_style
-    )
-    @browse_prev_day = ChannelBrowse::Day.new(
-      channel: @channel, date: @date.prev_day, style: @list_style
-    )
-    @browse_next_day = ChannelBrowse::Day.new(
-      channel: @channel, date: @date.next_day, style: @list_style
-    )
+    @browse_day =
+      (params[:style] == 'raw') ? @browse_day_raw : @browse_day_normal
+    @browse_prev_day = @browse_day.prev_day
+    @browse_next_day = @browse_day.next_day
 
     whole_messages =
-      if @list_style == :raw
+      if @browse_day.is_style_raw?
         HourSeparator.for_day_browse(@date) + messages + @conversation_messages
       else
         messages + @conversation_messages

--- a/app/controllers/channels/months_controller.rb
+++ b/app/controllers/channels/months_controller.rb
@@ -1,6 +1,6 @@
 class Channels::MonthsController < ApplicationController
   def index
-    @channel = Channel.find_by(identifier: params[:identifier])
+    @channel = Channel.friendly.find(params[:id])
     @year = params[:year].to_i
 
     start_date = Date.new(@year, 1, 1)

--- a/app/controllers/channels/months_controller.rb
+++ b/app/controllers/channels/months_controller.rb
@@ -3,6 +3,10 @@ class Channels::MonthsController < ApplicationController
     @channel = Channel.friendly.find(params[:id])
     @year = params[:year].to_i
 
+    browse_year = ChannelBrowse::Year.new(channel: @channel, year: @year)
+    @browse_prev_year = browse_year.prev_year
+    @browse_next_year = browse_year.next_year
+
     start_date = Date.new(@year, 1, 1)
     @month_count = MessageDate.
       uniq.

--- a/app/models/channel_browse/day.rb
+++ b/app/models/channel_browse/day.rb
@@ -55,6 +55,47 @@ class ChannelBrowse::Day
     end
   end
 
+  # メッセージが記録されている前の日の閲覧を返す
+  # @return [ChannelBrowse::Day] メッセージが記録されている前の日の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最初の日だった場合
+  def prev_day
+    return nil unless valid?
+
+    prev_message_date = MessageDate.
+      where(channel: @channel).
+      where('date < ?', date).
+      order(date: :desc).
+      first
+
+    return nil unless prev_message_date
+
+    browse_day = self.dup
+    browse_day.date = prev_message_date.date
+
+    browse_day
+  end
+
+
+  # メッセージが記録されている次の日の閲覧を返す
+  # @return [ChannelBrowse::Day] メッセージが記録されている次の日の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最後の日だった場合
+  def next_day
+    return nil unless valid?
+
+    next_message_date = MessageDate.
+      where(channel: @channel).
+      where('date > ?', date).
+      order(:date).
+      first
+
+    return nil unless next_message_date
+
+    browse_day = self.dup
+    browse_day.date = next_message_date.date
+
+    browse_day
+  end
+
   # URLを求める際に使うパラメータのハッシュを返す
   # @return [Hash] URLを求める際に使うパラメータのハッシュ
   # @return [nil] 属性が無効な場合

--- a/app/models/channel_browse/month.rb
+++ b/app/models/channel_browse/month.rb
@@ -67,4 +67,41 @@ class ChannelBrowse::Month
       params_for_url.merge(params).merge({ host: host })
     )
   end
+
+  # メッセージが記録されている前の月の閲覧を返す
+  # @return [ChannelBrowse::Month] メッセージが記録されている前の月の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最初の月だった場合
+  def prev_month
+    return nil unless valid?
+
+    prev_message_date = MessageDate.
+      where(channel: @channel).
+      where('date < ?', Date.new(@year, @month, 1)).
+      order(date: :desc).
+      first
+
+    return nil unless prev_message_date
+
+    date = prev_message_date.date
+    self.class.new(channel: @channel, year: date.year, month: date.month)
+  end
+
+
+  # メッセージが記録されている次の月の閲覧を返す
+  # @return [ChannelBrowse::Month] メッセージが記録されている次の月の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最後の月だった場合
+  def next_month
+    return nil unless valid?
+
+    next_message_date = MessageDate.
+      where(channel: @channel).
+      where('date >= ?', Date.new(@year, @month, 1).next_month).
+      order(:date).
+      first
+
+    return nil unless next_message_date
+
+    date = next_message_date.date
+    self.class.new(channel: @channel, year: date.year, month: date.month)
+  end
 end

--- a/app/models/channel_browse/month.rb
+++ b/app/models/channel_browse/month.rb
@@ -37,9 +37,34 @@ class ChannelBrowse::Month
     return nil unless valid?
 
     {
-      identifier: @channel&.identifier,
       year: @year.to_s,
       month: '%02d' % @month,
     }
+  end
+
+  # 月のページのパスを返す
+  # @param [Hash] params 追加のパラメータ
+  # @return [String] ログ閲覧ページのパス
+  # @return [nil] 属性が無効な場合
+  def path(params = {})
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_days_path(
+      @channel, params_for_url.merge(params)
+    )
+  end
+
+  # 月のページの URL を返す
+  # @param [String] host ホスト名。スキーム付きでもよい
+  # @param [Hash] params 追加のパラメータ
+  # @return [String] ログ閲覧ページの URL
+  # @return [nil] 属性が無効な場合
+  def url(host, params = {})
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_days_url(
+      @channel,
+      params_for_url.merge(params).merge({ host: host })
+    )
   end
 end

--- a/app/models/channel_browse/year.rb
+++ b/app/models/channel_browse/year.rb
@@ -25,8 +25,33 @@ class ChannelBrowse::Year
     return nil unless valid?
 
     {
-      identifier: @channel&.identifier,
       year: @year.to_s
     }
+  end
+
+  # 年のページのパスを返す
+  # @param [Hash] params 追加のパラメータ
+  # @return [String] 年のページのパス
+  # @return [nil] 属性が無効な場合
+  def path(params = {})
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_months_path(
+      @channel, params_for_url.merge(params)
+    )
+  end
+
+  # 年のページの URL を返す
+  # @param [String] host ホスト名。スキーム付きでもよい
+  # @param [Hash] params 追加のパラメータ
+  # @return [String] 年のページの URL
+  # @return [nil] 属性が無効な場合
+  def url(host, params = {})
+    return nil unless valid?
+
+    Rails.application.routes.url_helpers.channels_months_url(
+      @channel,
+      params_for_url.merge(params).merge({ host: host })
+    )
   end
 end

--- a/app/models/channel_browse/year.rb
+++ b/app/models/channel_browse/year.rb
@@ -54,4 +54,41 @@ class ChannelBrowse::Year
       params_for_url.merge(params).merge({ host: host })
     )
   end
+
+  # メッセージが記録されている前の年の閲覧を返す
+  # @return [ChannelBrowse::Year] メッセージが記録されている前の年の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最初の年だった場合
+  def prev_year
+    return nil unless valid?
+
+    prev_message_date = MessageDate.
+      where(channel: @channel).
+      where('date < ?', Date.new(@year, 1, 1)).
+      order(date: :desc).
+      first
+
+    return nil unless prev_message_date
+
+    date = prev_message_date.date
+    self.class.new(channel: @channel, year: date.year)
+  end
+
+
+  # メッセージが記録されている次の年の閲覧を返す
+  # @return [ChannelBrowse::Year] メッセージが記録されている次の年の閲覧
+  # @return [nil] 属性が無効、またはメッセージが記録されている最後の年だった場合
+  def next_year
+    return nil unless valid?
+
+    next_message_date = MessageDate.
+      where(channel: @channel).
+      where('date >= ?', Date.new(@year, 1, 1).next_year).
+      order(:date).
+      first
+
+    return nil unless next_message_date
+
+    date = next_message_date.date
+    self.class.new(channel: @channel, year: date.year)
+  end
 end

--- a/app/views/channels/days/_next_day.html.erb
+++ b/app/views/channels/days/_next_day.html.erb
@@ -1,0 +1,5 @@
+<p class="text-right">
+  <% if @browse_next_day %>
+    <%= link_to(raw("次の日 #{fa_icon('chevron-right')}"), @browse_next_day.path, class: 'btn btn-primary btn-sm') %>
+  <% end %>
+</p>

--- a/app/views/channels/days/_prev_day.html.erb
+++ b/app/views/channels/days/_prev_day.html.erb
@@ -1,0 +1,5 @@
+<p>
+  <% if @browse_prev_day %>
+    <%= link_to(fa_icon('chevron-left', text: '前の日'), @browse_prev_day.path, class: 'btn btn-primary btn-sm') %>
+  <% end %>
+</p>

--- a/app/views/channels/days/index.html.erb
+++ b/app/views/channels/days/index.html.erb
@@ -8,11 +8,10 @@
         <div class="panel-body">
           <%= render('shared/flash') %>
 
-          <% browse_year = ChannelBrowse::Year.new(channel: @channel, year: @year) %>
           <ol class="breadcrumb">
             <li><%= link_to('チャンネル', channels_path) %></li>
             <li><%= link_to(@channel.name_with_prefix, @channel) %></li>
-            <li><%= link_to("#{@year}年", channels_months_path(browse_year.params_for_url)) %></li>
+            <li><%= link_to("#{@year}年", @browse_year.path) %></li>
             <li class="active"><%= @month %>月</li>
           </ol>
 

--- a/app/views/channels/days/index.html.erb
+++ b/app/views/channels/days/index.html.erb
@@ -19,12 +19,29 @@
           <div class="page-header">
             <h1><%= @channel.name_with_prefix %> <%= year_month_str %></h1>
           </div>
+
           <ul>
             <% @dates.each do |date| %>
               <% browse_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
               <li><%= link_to(date.strftime('%F'), browse_day.path) %>（<%= @speech_count[date] || 0 %> 発言）</li>
             <% end %>
           </ul>
+
+          <% if @browse_prev_month || @browse_next_month %>
+            <div class="row">
+              <div class="col-xs-6">
+                <% if @browse_prev_month %>
+                  <p><%= link_to(fa_icon('chevron-left', text: '前の月'), @browse_prev_month.path, class: 'btn btn-primary btn-sm') %></p>
+                <% end %>
+              </div>
+
+              <div class="col-xs-6">
+                <% if @browse_next_month %>
+                  <p class="text-right"><%= link_to(raw("次の月 #{fa_icon('chevron-right')}"), @browse_next_month.path, class: 'btn btn-primary btn-sm') %></p>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -54,19 +54,19 @@
 
             <div class="row">
               <div class="col-xs-6">
-                <p><%= link_to(fa_icon('chevron-left', text: '前日'), @browse_prev_day.path, class: 'btn btn-primary btn-sm') %></p>
+                <%= render('prev_day') %>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(raw("翌日 #{fa_icon('chevron-right')}"), @browse_next_day.path, class: 'btn btn-primary btn-sm') %></p>
+                <%= render('next_day') %>
               </div>
             </div>
 
             <ul class="nav nav-tabs">
-              <li role="presentation" class="<%= nav_tab_class(@list_style == :normal) %>"><%= link_to('通常表示', (@list_style == :normal) ? '#' : @browse_day.path) %></a></li>
-              <li role="presentation" class="<%= nav_tab_class(@list_style == :raw) %>"><%= link_to('生ログ', (@list_style == :raw) ? '#' : @browse_day.path) %></a></li>
+              <li role="presentation" class="<%= nav_tab_class(@browse_day.is_style_normal?) %>"><%= link_to('通常表示', @browse_day.is_style_normal? ? '#' : @browse_day_normal.path) %></a></li>
+              <li role="presentation" class="<%= nav_tab_class(@browse_day.is_style_raw?) %>"><%= link_to('生ログ', @browse_day.is_style_raw? ? '#' : @browse_day_raw.path) %></a></li>
             </ul>
 
-            <% if @list_style == :raw %>
+            <% if @browse_day.is_style_raw? %>
               <div class="raw-log">
                 <%= render(partial: 'raw_message', collection: @sorted_messages, as: :m) %>
               </div>
@@ -78,10 +78,10 @@
 
             <div class="row">
               <div class="col-xs-6">
-                <p><%= link_to(fa_icon('chevron-left', text: '前日'), @browse_prev_day.path, class: 'btn btn-primary btn-sm') %></p>
+                <%= render('prev_day') %>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(raw("翌日 #{fa_icon('chevron-right')}"), @browse_next_day.path, class: 'btn btn-primary btn-sm') %></p>
+                <%= render('next_day') %>
               </div>
             </div>
           </article>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -52,14 +52,16 @@
               </table>
             </div>
 
-            <div class="row">
-              <div class="col-xs-6">
-                <%= render('prev_day') %>
+            <% if @browse_prev_day || @browse_next_day %>
+              <div class="row">
+                <div class="col-xs-6">
+                  <%= render('prev_day') %>
+                </div>
+                <div class="col-xs-6">
+                  <%= render('next_day') %>
+                </div>
               </div>
-              <div class="col-xs-6">
-                <%= render('next_day') %>
-              </div>
-            </div>
+            <% end %>
 
             <ul class="nav nav-tabs">
               <li role="presentation" class="<%= nav_tab_class(@browse_day.is_style_normal?) %>"><%= link_to('通常表示', @browse_day.is_style_normal? ? '#' : @browse_day_normal.path) %></a></li>
@@ -75,7 +77,9 @@
             <% end %>
 
             <div class="alert alert-info no-message-to-show">表示するメッセージがありません。</div>
+          </article>
 
+          <% if @browse_prev_day || @browse_next_day %>
             <div class="row">
               <div class="col-xs-6">
                 <%= render('prev_day') %>
@@ -84,7 +88,7 @@
                 <%= render('next_day') %>
               </div>
             </div>
-          </article>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -57,7 +57,7 @@
                 <p><%= link_to(fa_icon('chevron-left', text: '前日'), channels_day_path(@browse_prev_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p class="text-right"><%= link_to(raw("翌日 #{fa_icon('chevron-right')}"), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
               </div>
             </div>
 
@@ -81,7 +81,7 @@
                 <p><%= link_to(fa_icon('chevron-left', text: '前日'), channels_day_path(@browse_prev_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
               </div>
               <div class="col-xs-6">
-                <p class="text-right"><%= link_to(fa_icon('chevron-right', text: '翌日'), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
+                <p class="text-right"><%= link_to(raw("翌日 #{fa_icon('chevron-right')}"), channels_day_path(@browse_next_day.params_for_url.merge(@day_link_params)), class: 'btn btn-primary btn-sm') %></p>
               </div>
             </div>
           </article>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -12,7 +12,7 @@
           <ol class="breadcrumb">
             <li><%= link_to('チャンネル', channels_path) %></li>
             <li><%= link_to(@channel.name_with_prefix, @channel) %></li>
-            <li><%= link_to("#{@date.year}年", channels_months_path(@browse_year.params_for_url)) %></li>
+            <li><%= link_to("#{@date.year}年", @browse_year.path) %></li>
             <li><%= link_to("#{@date.month}月", @browse_month.path) %></li>
             <li class="active"><%= @date.day %>日</li>
           </ol>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -13,7 +13,7 @@
             <li><%= link_to('チャンネル', channels_path) %></li>
             <li><%= link_to(@channel.name_with_prefix, @channel) %></li>
             <li><%= link_to("#{@date.year}年", channels_months_path(@browse_year.params_for_url)) %></li>
-            <li><%= link_to("#{@date.month}月", channels_days_path(@browse_month.params_for_url)) %></li>
+            <li><%= link_to("#{@date.month}月", @browse_month.path) %></li>
             <li class="active"><%= @date.day %>日</li>
           </ol>
 

--- a/app/views/channels/months/index.html.erb
+++ b/app/views/channels/months/index.html.erb
@@ -16,12 +16,29 @@
           <div class="page-header">
             <h1><%= @channel.name_with_prefix %> <%= @year %>年</h1>
           </div>
+
           <ul>
             <% @month_count.each do |month, count| %>
               <% browse_month = ChannelBrowse::Month.new(channel: @channel, year: @year, month: month) %>
               <li><%= link_to('%d-%02d' % [@year, month], browse_month.path) %> (<%= count %>)</li>
             <% end %>
           </ul>
+
+          <% if @browse_prev_year || @browse_next_year %>
+            <div class="row">
+              <div class="col-xs-6">
+                <% if @browse_prev_year %>
+                  <p><%= link_to(fa_icon('chevron-left', text: '前の年'), @browse_prev_year.path, class: 'btn btn-primary btn-sm') %></p>
+                <% end %>
+              </div>
+
+              <div class="col-xs-6">
+                <% if @browse_next_year %>
+                  <p class="text-right"><%= link_to(raw("次の年 #{fa_icon('chevron-right')}"), @browse_next_year.path, class: 'btn btn-primary btn-sm') %></p>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/channels/months/index.html.erb
+++ b/app/views/channels/months/index.html.erb
@@ -19,7 +19,7 @@
           <ul>
             <% @month_count.each do |month, count| %>
               <% browse_month = ChannelBrowse::Month.new(channel: @channel, year: @year, month: month) %>
-              <li><%= link_to('%d-%02d' % [@year, month], channels_days_path(browse_month.params_for_url)) %> (<%= count %>)</li>
+              <li><%= link_to('%d-%02d' % [@year, month], browse_month.path) %> (<%= count %>)</li>
             <% end %>
           </ul>
         </div>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -19,7 +19,7 @@
           <ul>
             <% @years.each do |year| %>
               <% browse_year = ChannelBrowse::Year.new(channel: @channel, year: year) %>
-              <li><%= link_to("#{year}年", channels_months_path(browse_year.params_for_url)) %></li>
+              <li><%= link_to("#{year}年", browse_year.path) %></li>
             <% end %>
           </ul>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,9 @@ Rails.application.routes.draw do
   namespace :channels do
     get ':id/:year/:month/:day', to: 'days#show', as: 'day',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/, day: /0[1-9]|[12][0-9]|3[01]/
-    get ':identifier/:year/:month', to: 'days#index', as: 'days',
+    get ':id/:year/:month', to: 'days#index', as: 'days',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/
-    get ':identifier/:year', to: 'months#index', as: 'months', year: /[1-9][0-9]{3}/
+    get ':id/:year', to: 'months#index', as: 'months', year: /[1-9][0-9]{3}/
   end
 
   namespace :messages do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,4 +116,5 @@ ActiveRecord::Schema.define(version: 20170408163604) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   add_foreign_key "channel_last_speeches", "conversation_messages", name: "conversation_message_id"
+  add_foreign_key "conversation_messages", "irc_users", name: "irc_user_id"
 end

--- a/test/factories/channel_browse/months.rb
+++ b/test/factories/channel_browse/months.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :channel_browse_month, class: ChannelBrowse::Month do
     channel
     year 2017
-    month 1
+    month 2
   end
 end

--- a/test/factories/message_dates.rb
+++ b/test/factories/message_dates.rb
@@ -7,6 +7,10 @@ FactoryGirl.define do
       MessageDate.find_or_create_by(channel: channel, date: date)
     }
 
+    factory :message_date_20150123 do
+      date '2015-01-23'
+    end
+
     factory :message_date_20161231 do
       date '2016-12-31'
     end

--- a/test/factories/message_dates.rb
+++ b/test/factories/message_dates.rb
@@ -1,5 +1,18 @@
 FactoryGirl.define do
   factory :message_date do
-    date "2016-08-16"
+    channel
+    date '2016-08-16'
+
+    initialize_with {
+      MessageDate.find_or_create_by(channel: channel, date: date)
+    }
+
+    factory :message_date_20161231 do
+      date '2016-12-31'
+    end
+
+    factory :message_date_20170401 do
+      date '2017-04-01'
+    end
   end
 end

--- a/test/models/channel_browse/day_test.rb
+++ b/test/models/channel_browse/day_test.rb
@@ -135,4 +135,56 @@ class ChannelBrowse::DayTest < ActiveSupport::TestCase
     assert_equal('https://log.example.net/channels/irc_test/2017/04/01?style=raw#12345',
                  @day.url('https://log.example.net', anchor: '12345'))
   end
+
+  def prepare_message_dates
+    MessageDate.delete_all
+
+    @message_date_20160816 = create(:message_date)
+    @message_date_20161231 = create(:message_date_20161231)
+    @message_date_20170401 = create(:message_date_20170401)
+  end
+
+  test 'prev_day: メッセージが記録されている前の日の閲覧を返す' do
+    prepare_message_dates
+
+    @day.date = @message_date_20161231.date
+    @day.style = :raw
+
+    prev_day = @day.prev_day
+
+    assert_equal(@channel, prev_day.channel, 'チャンネルが正しい')
+    assert_equal(@message_date_20160816.date, prev_day.date, '日付が正しい')
+    assert_equal(:raw, prev_day.style, '表示のスタイルが正しい')
+    assert(prev_day.valid?)
+  end
+
+  test 'prev_day: メッセージが記録されている最初の日だった場合nilを返す' do
+    prepare_message_dates
+
+    @day.date = @message_date_20160816.date
+
+    assert_nil(@day.prev_day)
+  end
+
+  test 'next_day: メッセージが記録されている次の日の閲覧を返す' do
+    prepare_message_dates
+
+    @day.date = @message_date_20161231.date
+    @day.style = :raw
+
+    next_day = @day.next_day
+
+    assert_equal(@channel, next_day.channel, 'チャンネルが正しい')
+    assert_equal(@message_date_20170401.date, next_day.date, '日付が正しい')
+    assert_equal(:raw, next_day.style, '表示のスタイルが正しい')
+    assert(next_day.valid?)
+  end
+
+  test 'next_day: メッセージが記録されている最後の日だった場合nilを返す' do
+    prepare_message_dates
+
+    @day.date = @message_date_20170401.date
+
+    assert_nil(@day.next_day)
+  end
 end

--- a/test/models/channel_browse/month_test.rb
+++ b/test/models/channel_browse/month_test.rb
@@ -80,4 +80,64 @@ class ChannelBrowse::MonthTest < ActiveSupport::TestCase
     assert_equal('https://log.example.net/channels/irc_test/2017/02#12345',
                  @month.url('https://log.example.net', anchor: '12345'))
   end
+
+  def prepare_message_dates
+    MessageDate.delete_all
+
+    @message_date_20160816 = create(:message_date)
+    @message_date_20161231 = create(:message_date_20161231)
+    @message_date_20170401 = create(:message_date_20170401)
+  end
+
+  test 'prev_month: メッセージが記録されている前の月の閲覧を返す' do
+    prepare_message_dates
+
+    date = @message_date_20161231.date
+    @month.year = date.year
+    @month.month = date.month
+
+    prev_date = @message_date_20160816.date
+    prev_month = @month.prev_month
+
+    assert_equal(@month.channel, prev_month.channel, 'チャンネルが正しい')
+    assert_equal(prev_date.year, prev_month.year, '年が正しい')
+    assert_equal(prev_date.month, prev_month.month, '月が正しい')
+    assert(prev_month.valid?)
+  end
+
+  test 'prev_month: メッセージが記録されている最初の月だった場合nilを返す' do
+    prepare_message_dates
+
+    date = @message_date_20160816.date
+    @month.year = date.year
+    @month.month = date.month
+
+    assert_nil(@month.prev_month)
+  end
+
+  test 'next_month: メッセージが記録されている次の月の閲覧を返す' do
+    prepare_message_dates
+
+    date = @message_date_20161231.date
+    @month.year = date.year
+    @month.month = date.month
+
+    next_date = @message_date_20170401.date
+    next_month = @month.next_month
+
+    assert_equal(@month.channel, next_month.channel, 'チャンネルが正しい')
+    assert_equal(next_date.year, next_month.year, '年が正しい')
+    assert_equal(next_date.month, next_month.month, '月が正しい')
+    assert(next_month.valid?)
+  end
+
+  test 'next_month: メッセージが記録されている最後の月だった場合nilを返す' do
+    prepare_message_dates
+
+    date = @message_date_20170401.date
+    @month.year = date.year
+    @month.month = date.month
+
+    assert_nil(@month.next_month)
+  end
 end

--- a/test/models/channel_browse/month_test.rb
+++ b/test/models/channel_browse/month_test.rb
@@ -53,8 +53,31 @@ class ChannelBrowse::MonthTest < ActiveSupport::TestCase
   test 'params_for_url の結果が正しい' do
     params = @month.params_for_url
 
-    assert_equal(@month.channel.identifier, params.fetch(:identifier), 'identifier')
     assert_equal(@month.year.to_s, params.fetch(:year), 'year')
     assert_equal('%02d' % @month.month, params.fetch(:month), 'month')
+  end
+
+  test 'path: 月のページのパスが正しい' do
+    assert_equal('/channels/irc_test/2017/02', @month.path)
+  end
+
+  test 'path: フラグメント識別子を指定することができる' do
+    assert_equal('/channels/irc_test/2017/02#12345',
+                 @month.path(anchor: '12345'))
+  end
+
+  test 'url: 月のページの URL が正しい（スキーム付き）' do
+    assert_equal('https://log.example.net/channels/irc_test/2017/02',
+                 @month.url('https://log.example.net'))
+  end
+
+  test 'url: 月のページの URL が正しい（スキームなし）' do
+    assert_equal('http://log.example.net/channels/irc_test/2017/02',
+                 @month.url('log.example.net'))
+  end
+
+  test 'url: フラグメント識別子を指定することができる' do
+    assert_equal('https://log.example.net/channels/irc_test/2017/02#12345',
+                 @month.url('https://log.example.net', anchor: '12345'))
   end
 end

--- a/test/models/channel_browse/year_test.rb
+++ b/test/models/channel_browse/year_test.rb
@@ -53,4 +53,58 @@ class ChannelBrowse::YearTest < ActiveSupport::TestCase
     assert_equal('https://log.example.net/channels/irc_test/2017#12345',
                  @year.url('https://log.example.net', anchor: '12345'))
   end
+
+  def prepare_message_dates
+    MessageDate.delete_all
+
+    @message_date_20150123 = create(:message_date_20150123)
+    @message_date_20161231 = create(:message_date_20161231)
+    @message_date_20170401 = create(:message_date_20170401)
+  end
+
+  test 'prev_year: メッセージが記録されている前の年の閲覧を返す' do
+    prepare_message_dates
+
+    date = @message_date_20161231.date
+    @year.year = date.year
+
+    prev_date = @message_date_20150123.date
+    prev_year = @year.prev_year
+
+    assert_equal(@year.channel, prev_year.channel, 'チャンネルが正しい')
+    assert_equal(prev_date.year, prev_year.year, '年が正しい')
+    assert(prev_year.valid?)
+  end
+
+  test 'prev_year: メッセージが記録されている最初の年だった場合nilを返す' do
+    prepare_message_dates
+
+    date = @message_date_20150123.date
+    @year.year = date.year
+
+    assert_nil(@year.prev_year)
+  end
+
+  test 'next_year: メッセージが記録されている次の年の閲覧を返す' do
+    prepare_message_dates
+
+    date = @message_date_20161231.date
+    @year.year = date.year
+
+    next_date = @message_date_20170401.date
+    next_year = @year.next_year
+
+    assert_equal(@year.channel, next_year.channel, 'チャンネルが正しい')
+    assert_equal(next_date.year, next_year.year, '年が正しい')
+    assert(next_year.valid?)
+  end
+
+  test 'next_year: メッセージが記録されている最後の年だった場合nilを返す' do
+    prepare_message_dates
+
+    date = @message_date_20170401.date
+    @year.year = date.year
+
+    assert_nil(@year.next_year)
+  end
 end

--- a/test/models/channel_browse/year_test.rb
+++ b/test/models/channel_browse/year_test.rb
@@ -27,7 +27,30 @@ class ChannelBrowse::YearTest < ActiveSupport::TestCase
   test 'params_for_url の結果が正しい' do
     params = @year.params_for_url
 
-    assert_equal(@year.channel.identifier, params.fetch(:identifier), 'identifier')
     assert_equal(@year.year.to_s, params.fetch(:year), 'year')
+  end
+
+  test 'path: 年のページのパスが正しい' do
+    assert_equal('/channels/irc_test/2017', @year.path)
+  end
+
+  test 'path: フラグメント識別子を指定することができる' do
+    assert_equal('/channels/irc_test/2017#12345',
+                 @year.path(anchor: '12345'))
+  end
+
+  test 'url: 年のページの URL が正しい（スキーム付き）' do
+    assert_equal('https://log.example.net/channels/irc_test/2017',
+                 @year.url('https://log.example.net'))
+  end
+
+  test 'url: 年のページの URL が正しい（スキームなし）' do
+    assert_equal('http://log.example.net/channels/irc_test/2017',
+                 @year.url('log.example.net'))
+  end
+
+  test 'url: フラグメント識別子を指定することができる' do
+    assert_equal('https://log.example.net/channels/irc_test/2017#12345',
+                 @year.url('https://log.example.net', anchor: '12345'))
   end
 end


### PR DESCRIPTION
fixes #59

月や日の一覧および1日分のページにおいて隣（メッセージが記録されている年・月・日）へのリンクが表示されるようにします。メッセージが記録されていない年・月・日はスキップされ、端の場合はその方向にさらに進むためのリンクが表示されないようにします。