### PR TITLE
月のページで発言数のグラフを描く

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,9 @@ gem 'sorcery'
 # 並び替え
 gem 'ranked-model'
 
+# グラフ描画
+gem 'chart-js-rails'
+
 # コンソールとして pry を使う
 gem 'pry-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       momentjs-rails (>= 2.8.1)
     builder (3.2.3)
     byebug (9.0.6)
+    chart-js-rails (0.1.2)
+      railties (> 3.1)
     cinch (2.3.3)
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
@@ -294,6 +296,7 @@ DEPENDENCIES
   bootstrap-sass
   bootstrap3-datetimepicker-rails (~> 4.17)
   byebug
+  chart-js-rails
   cinch
   codeclimate-test-reporter (~> 1.0.0)
   coffee-rails (~> 4.1.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require moment/ja
 //= require bootstrap-datetimepicker
 //= require ./datetimepicker
+//= require Chart
 //= require log_archiver
 //= require_tree .
 

--- a/app/assets/javascripts/channels/days.js
+++ b/app/assets/javascripts/channels/days.js
@@ -165,6 +165,86 @@
       updateJoinPartMessagesVisibility();
 
       updateViews();
+    },
+
+    index: function index() {
+      var $dateListItems = $('#date-list > li');
+      var $ctx = $('#speeches-chart');
+
+      if ($ctx.length <= 0) {
+        return;
+      }
+
+      var dates = [];
+      var labels = [];
+      var values = [];
+      var data = {
+        labels: labels,
+        datasets: [
+          {
+            label: '発言数',
+            data: values,
+            backgroundColor: '#E64A19'
+          }
+        ]
+      };
+
+      $dateListItems.each(function () {
+        var $item = $(this);
+
+        dates.push($item.data('date'));
+        labels.push($item.data('day'));
+        values.push(parseInt($item.data('num-of-speeches'), 10));
+      });
+
+      var speechesChart = new Chart($ctx, {
+        type: 'bar',
+        data: data,
+        options: {
+          scales: {
+            yAxes: [{
+              ticks: {
+                beginAtZero: true
+              }
+            }]
+          },
+
+          legend: {
+            display: false
+          },
+
+          tooltips: {
+            callbacks: {
+              title: function (tooltipItems, data) {
+                var tooltipItem = tooltipItems[0];
+                return dates[tooltipItem.index];
+              }
+            }
+          },
+
+          hover: {
+            onHover: function (e, elements) {
+              $ctx.css('cursor', elements[0] ? 'pointer' : 'default');
+            }
+          },
+
+          animation: {
+            duration: 400
+          }
+        }
+      });
+
+      $ctx.click(function (evt) {
+        var activePoints = speechesChart.getElementsAtEvent(evt);
+        var clicked;
+        var href;
+
+        if (activePoints.length > 0) {
+          clicked = activePoints[0];
+          href = document.location.pathname + '/' + dates[clicked._index].slice(8);
+          document.location.href = href;
+        }
+      });
     }
   };
 }());

--- a/app/views/channels/days/index.html.erb
+++ b/app/views/channels/days/index.html.erb
@@ -20,10 +20,11 @@
               <h1><%= @channel.name_with_prefix %> <%= year_month_str %></h1>
             </div>
 
-            <ul>
+            <ul id="date-list" class="date-list">
               <% @dates.each do |date| %>
                 <% browse_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
-                <li><%= link_to(date.strftime('%F'), browse_day.path) %>（<%= @speech_count[date] || 0 %> 発言）</li>
+                <% num_of_speeches = @speech_count[date] || 0 %>
+                <li data-date="<%= date.strftime('%F') %>" data-day="<%= date.day %>" data-num-of-speeches="<%= num_of_speeches %>"><%= link_to(date.strftime('%F'), browse_day.path) %>（<%= num_of_speeches %> 発言）</li>
               <% end %>
             </ul>
           </article>
@@ -48,6 +49,18 @@
     </div>
 
     <aside class="col-xs-12 col-md-4">
+      <% if @dates.length > 0 %>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h1 class="panel-title">発言数</h1>
+          </div>
+
+          <div class="panel-body">
+            <canvas id="speeches-chart" width="400" height="300"></canvas>
+          </div>
+        </div>
+      <% end %>
+
       <div class="panel panel-default">
         <div class="panel-heading">
           <h1 class="panel-title"><%= @channel.name_with_prefix %></h1>
@@ -56,11 +69,12 @@
         <div class="panel-body">
           <ul class="list-unstyled year-month-list">
             <% @years.each do |year| %>
+              <% year_str = "#{year}年" %>
               <% browse_year = ChannelBrowse::Year.new(channel: @channel, year: year) %>
 
               <% if year == @year %>
                 <li>
-                  <%= link_to(year, browse_year.path) %>
+                  <%= link_to(year_str, browse_year.path) %>
                   <ul class="list-unstyled month-list-in-the-year">
                     <% @year_months_in_the_year.each do |_, month| %>
                       <% year_month_str_month_list = '%d-%02d' % [@year, month] %>
@@ -74,7 +88,7 @@
                   </ul>
                 </li>
               <% else %>
-                <li><%= link_to(year, browse_year.path) %></li>
+                <li><%= link_to(year_str, browse_year.path) %></li>
               <% end %>
             <% end %>
           </ul>


### PR DESCRIPTION
実験的ですが、月のページで各日付の発言数を表示するグラフをサイドバーに追加してみました。発言数の多い日がひと目で分かります。棒グラフをクリックすることでその日のページに飛ぶこともできます。

![#もの書き 2017-04の発言数のグラフ](https://cloud.githubusercontent.com/assets/2551173/25561143/41158766-2da0-11e7-87b5-38a4e8fe7aa3.png)
例：https://log.irc.cre.jp/channels/write/2017/04