### PR TITLE
今日と昨日のページのURLを設定する

### DIFF
--- a/app/controllers/channels/today_controller.rb
+++ b/app/controllers/channels/today_controller.rb
@@ -1,0 +1,7 @@
+class Channels::TodayController < ApplicationController
+  def show
+    channel = Channel.friendly.find(params[:id])
+    browse_today = ChannelBrowse::Day.today(channel)
+    redirect_to(browse_today.path)
+  end
+end

--- a/app/controllers/channels/yesterday_controller.rb
+++ b/app/controllers/channels/yesterday_controller.rb
@@ -1,0 +1,7 @@
+class Channels::YesterdayController < ApplicationController
+  def show
+    channel = Channel.friendly.find(params[:id])
+    browse_yesterday = ChannelBrowse::Day.yesterday(channel)
+    redirect_to(browse_yesterday.path)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resource :browse, only: %i(create)
 
   namespace :channels do
+    get ':id/today', to: 'today#show', as: 'today'
     get ':id/:year/:month/:day', to: 'days#show', as: 'day',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/, day: /0[1-9]|[12][0-9]|3[01]/
     get ':id/:year/:month', to: 'days#index', as: 'days',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   namespace :channels do
     get ':id/today', to: 'today#show', as: 'today'
+    get ':id/yesterday', to: 'yesterday#show', as: 'yesterday'
     get ':id/:year/:month/:day', to: 'days#show', as: 'day',
       year: /[1-9][0-9]{3}/, month: /0[1-9]|1[0-2]/, day: /0[1-9]|[12][0-9]|3[01]/
     get ':id/:year/:month', to: 'days#index', as: 'days',

--- a/test/controllers/channels/today_controller_test.rb
+++ b/test/controllers/channels/today_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Channels::TodayControllerTest < ActionController::TestCase
+  setup do
+    Channel.delete_all
+    @channel = create(:channel)
+  end
+
+  teardown do
+    Channel.delete_all
+  end
+
+  test '今日のページにリダイレクトされる' do
+    today = Time.zone.local(2017, 5, 1)
+
+    travel_to(today) do
+      get(:show, id: @channel.id)
+
+      browse_day = ChannelBrowse::Day.new(channel: @channel, date: today)
+      assert_redirected_to(browse_day.path)
+    end
+  end
+end

--- a/test/controllers/channels/yesterday_controller_test.rb
+++ b/test/controllers/channels/yesterday_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Channels::YesterdayControllerTest < ActionController::TestCase
+  setup do
+    Channel.delete_all
+    @channel = create(:channel)
+  end
+
+  teardown do
+    Channel.delete_all
+  end
+
+  test '昨日のページにリダイレクトされる' do
+    today = Time.zone.local(2017, 5, 1)
+
+    travel_to(today) do
+      get(:show, id: @channel.id)
+
+      browse_day = ChannelBrowse::Day.new(channel: @channel, date: Date.new(2017, 4, 30))
+      assert_redirected_to(browse_day.path)
+    end
+  end
+end


### PR DESCRIPTION
現在のポータルと同じように、今日と昨日のログのページに簡単なURLでアクセスできるようにしました。

例：

* 今日：/channels/write/today
* 昨日：/channels/write/yesterday