### PR TITLE
irc-version-commitid: バージョンとともに git の現在のコミットIDを表示するようにした

### DIFF
--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -48,7 +48,14 @@ module LogArchiver
 
       OptionParser.new do |opt|
         opt.banner = "使用法: #{opt.program_name} [オプション]"
-        opt.version = "#{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
+
+        commit_id = `git show -s --format=%H`.chomp rescue ''
+        opt.version =
+          if commit_id.empty?
+            Application::VERSION
+          else
+            "#{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
+          end
 
         opt.summary_indent = ' ' * 2
         opt.summary_width = 24

--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -48,7 +48,7 @@ module LogArchiver
 
       OptionParser.new do |opt|
         opt.banner = "使用法: #{opt.program_name} [オプション]"
-        opt.version = Application::VERSION
+        opt.version = "#{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
 
         opt.summary_indent = ' ' * 2
         opt.summary_width = 24

--- a/lib/ircs/plugins/version.rb
+++ b/lib/ircs/plugins/version.rb
@@ -13,8 +13,14 @@ module LogArchiver
 
       match(/version/, method: :version)
 
+      def initialize(*)
+        super
+
+        @version =  "IRC Log Archiver #{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
+      end
+
       def version(m)
-        send_and_record(m, "IRC Log Archiver #{Application::VERSION}")
+        send_and_record(m, @version)
       end
     end
   end

--- a/lib/ircs/plugins/version.rb
+++ b/lib/ircs/plugins/version.rb
@@ -16,7 +16,13 @@ module LogArchiver
       def initialize(*)
         super
 
-        @version =  "IRC Log Archiver #{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
+        commit_id = `git show -s --format=%H`.chomp rescue ''
+        @version =
+          if commit_id.empty?
+            "IRC Log Archiver #{Application::VERSION}"
+          else
+            "IRC Log Archiver #{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
+          end
       end
 
       def version(m)


### PR DESCRIPTION
開発版では、バージョン番号に加え、git のコミットIDも出力して欲しかったため実装した。

コマンドラインオプションでは実行したそのときのコミットIDを単純に取得するだけの処理を行なう。
しかし、IRCからバージョンコマンドを実行されたときには、起動時のコミットIDを表示する。
そのため、プラグインのコンストラクタで取得し、クラス変数に保存するようにした。