### PR TITLE
特定のページを検索エンジンに掲載させないようにする

### DIFF
--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -1,5 +1,7 @@
 <% date_str = @date.strftime('%F') %>
 <% title([@channel.name_with_prefix, date_str]) %>
+<% noindex if @browse_day.is_style_raw? %>
+
 <%= render('shared/navbar') %>
 <div class="container main-container">
 

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,4 +1,6 @@
 <% title('ログイン') %>
+<% noindex %>
+
 <%= render('shared/navbar') %>
 <div class="container main-container">
   <div class="row">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,7 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+
+# 今日・昨日は内容が常に変動するので許可しない
+Disallow: /channels/*/today
+Disallow: /channels/*/yesterday


### PR DESCRIPTION
https://log.irc.cre.jp/ がGoogle等に掲載されるようになってきましたが、1日分のページのスタイル違い（生ログ）や、内容が常に変わる今日・昨日のページ等も掲載されてしまい、使い勝手が悪くなっています。そこで、これらのページを掲載させないようにmetaタグやrobots.txtのエントリの追加を行いました。