### PR TITLE
メッセージ一覧のスタイルをCookieで保存する

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,6 +22,7 @@
 //= require ./datetimepicker
 //= require Chart
 //= require log_archiver
+//= require message_list_style
 //= require_tree .
 
 /*global $, logArchiver */

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery-ui/widgets/sortable
 //= require jquery-ui/effects/effect-highlight
 //= require bootstrap-sprockets
+//= require js.cookie
 //= require moment
 //= require moment/ja
 //= require bootstrap-datetimepicker

--- a/app/assets/javascripts/channels/days.js
+++ b/app/assets/javascripts/channels/days.js
@@ -192,6 +192,7 @@
       var $ctx = $('#speeches-chart');
 
       if ($ctx.length <= 0) {
+        // グラフが存在しなければ何もしない
         return;
       }
 
@@ -254,14 +255,21 @@
         }
       });
 
+      // 棒グラフの棒をクリックしたときの処理
       $ctx.click(function (evt) {
         var activePoints = speechesChart.getElementsAtEvent(evt);
         var clicked;
+        var dayPath;
         var href;
 
         if (activePoints.length > 0) {
           clicked = activePoints[0];
-          href = document.location.pathname + '/' + dates[clicked._index].slice(8);
+
+          // YYYY-mm-ddの9文字目から→dd
+          dayPath = document.location.pathname + '/' + dates[clicked._index].slice(8);
+
+          href = logArchiver.messageListStyle.get() === 'raw' ?
+            (dayPath + '/?style=raw') : dayPath;
           document.location.href = href;
         }
       });

--- a/app/assets/javascripts/channels/days.js
+++ b/app/assets/javascripts/channels/days.js
@@ -78,6 +78,24 @@
       // 参加・退出の表示・非表示のチェックボックス
       var $showJoinPart = $('#show-join-part');
 
+      // 通常表示タブ
+      var $messageListStyleNormalTab = $('#message-list-style-normal-tab');
+      // 生ログタブ
+      var $messageListStyleRawTab = $('#message-list-style-raw-tab');
+
+      // メッセージ表示スタイルのタブをクリックしたときのハンドラを設定する
+      var setMessageListStyleTabClickHandlers = function () {
+        if (rawLog) {
+          $messageListStyleNormalTab.click(function () {
+            logArchiver.messageListStyle.setNormal();
+          });
+        } else {
+          $messageListStyleRawTab.click(function () {
+            logArchiver.messageListStyle.setRaw();
+          });
+        }
+      };
+
       // メッセージ一覧の表
       var $messageList = $('.message-list');
 
@@ -146,6 +164,8 @@
           updateViews();
         };
       };
+
+      setMessageListStyleTabClickHandlers();
 
       visibilityController
         .addCategory('speeches', $speeches)

--- a/app/assets/javascripts/message_list_style.js
+++ b/app/assets/javascripts/message_list_style.js
@@ -1,0 +1,40 @@
+/*global logArchiver, Cookies */
+
+(function (ns) {
+  'use strict';
+
+  // Cookieの有効期限
+  var COOKIE_EXPIRE_DATE = 14;
+  // Cookieにおけるメッセージ表示スタイルのキー
+  var MESSAGE_LIST_STYLE_KEY = 'message_list_style';
+
+  /**
+   * @namespace
+   */
+  ns.messageListStyle = {
+    /**
+     * 設定されたメッセージ表示のスタイルを取得する。
+     * @return {string} 設定されたメッセージ表示のスタイル。
+     */
+    get: function () {
+      var value = Cookies.get(MESSAGE_LIST_STYLE_KEY);
+      return value === 'raw' ? 'raw' : 'normal';
+    },
+
+    /**
+     * メッセージ表示スタイルを通常表示に設定する。
+     */
+    setNormal: function () {
+      Cookies.set(MESSAGE_LIST_STYLE_KEY, 'normal',
+                  { expires: COOKIE_EXPIRE_DATE });
+    },
+
+    /**
+     * メッセージ表示スタイルを生ログに設定する。
+     */
+    setRaw: function () {
+      Cookies.set(MESSAGE_LIST_STYLE_KEY, 'raw',
+                  { expires: COOKIE_EXPIRE_DATE });
+    }
+  };
+}(logArchiver));

--- a/app/controllers/browses_controller.rb
+++ b/app/controllers/browses_controller.rb
@@ -5,6 +5,7 @@ class BrowsesController < ApplicationController
 
     if @channel_browse.valid?
       browse_day = @channel_browse.to_channel_browse_day
+      browse_day.style = self.class.helpers.message_list_style(cookies)
       redirect_to(browse_day.path)
     else
       @invalid_model = :channel_browse

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,9 @@ module ApplicationHelper
     last_speech = channel.last_speech
     if last_speech
       browse_day = ChannelBrowse::Day.new(
-        channel: channel, date: last_speech.timestamp.to_date
+        channel: channel,
+        date: last_speech.timestamp.to_date,
+        style: message_list_style(cookies)
       )
 
       link_to(last_speech.timestamp.strftime('%F %T'),

--- a/app/helpers/channels/days_helper.rb
+++ b/app/helpers/channels/days_helper.rb
@@ -1,2 +1,22 @@
 module Channels::DaysHelper
+  # メッセージ一覧のスタイルをCookieに保存する
+  # @param [Symbol] style メッセージ一覧のスタイル
+  # @param [Object] cookies Cookies
+  # @return [void]
+  def save_message_list_style(style, cookies)
+    value = (style == :raw) ? 'raw' : 'normal'
+    cookies[:message_list_style] = value
+  end
+
+  # メッセージ一覧のスタイルをCookieから取得する
+  # @param [Object] cookies Cookies
+  # @return [Symbol]
+  def message_list_style(cookies)
+    return @message_list_style if @message_list_style
+
+    style = (cookies[:message_list_style] == 'raw') ? :raw : :normal
+    @message_list_style = style
+
+    style
+  end
 end

--- a/app/helpers/channels/days_helper.rb
+++ b/app/helpers/channels/days_helper.rb
@@ -12,11 +12,6 @@ module Channels::DaysHelper
   # @param [Object] cookies Cookies
   # @return [Symbol]
   def message_list_style(cookies)
-    return @message_list_style if @message_list_style
-
-    style = (cookies[:message_list_style] == 'raw') ? :raw : :normal
-    @message_list_style = style
-
-    style
+    (cookies[:message_list_style] == 'raw') ? :raw : :normal
   end
 end

--- a/app/views/channels/days/index.html.erb
+++ b/app/views/channels/days/index.html.erb
@@ -22,7 +22,7 @@
 
             <ul id="date-list" class="date-list">
               <% @dates.each do |date| %>
-                <% browse_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
+                <% browse_day = ChannelBrowse::Day.new(channel: @channel, date: date, style: message_list_style(cookies)) %>
                 <% num_of_speeches = @speech_count[date] || 0 %>
                 <li data-date="<%= date.strftime('%F') %>" data-day="<%= date.day %>" data-num-of-speeches="<%= num_of_speeches %>"><%= link_to(date.strftime('%F'), browse_day.path) %>（<%= num_of_speeches %> 発言）</li>
               <% end %>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -75,7 +75,7 @@
                 <%= render(partial: 'raw_message', collection: @sorted_messages, as: :m) %>
               </div>
             <% else %>
-              <%= render('shared/message_list', messages: @sorted_messages, show_channel: false) %>
+              <%= render('shared/message_list', messages: @sorted_messages, show_channel: false, style: :normal) %>
             <% end %>
 
             <div class="alert alert-info no-message-to-show">表示するメッセージがありません。</div>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -66,8 +66,8 @@
             <% end %>
 
             <ul class="nav nav-tabs">
-              <li role="presentation" class="<%= nav_tab_class(@browse_day.is_style_normal?) %>"><%= link_to('通常表示', @browse_day.is_style_normal? ? '#' : @browse_day_normal.path) %></a></li>
-              <li role="presentation" class="<%= nav_tab_class(@browse_day.is_style_raw?) %>"><%= link_to('生ログ', @browse_day.is_style_raw? ? '#' : @browse_day_raw.path) %></a></li>
+              <li role="presentation" id="message-list-style-normal-tab" class="<%= nav_tab_class(@browse_day.is_style_normal?) %>"><%= link_to('通常表示', @browse_day.is_style_normal? ? '#' : @browse_day_normal.path) %></a></li>
+              <li role="presentation" id="message-list-style-raw-tab" class="<%= nav_tab_class(@browse_day.is_style_raw?) %>"><%= link_to('生ログ', @browse_day.is_style_raw? ? '#' : @browse_day_raw.path) %></a></li>
             </ul>
 
             <% if @browse_day.is_style_raw? %>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -100,7 +100,7 @@
             <% if events.empty? %>
               <%= date.day %>
             <% else %>
-              <% browse_other_day = ChannelBrowse::Day.new(channel: @channel, date: date) %>
+              <% browse_other_day = ChannelBrowse::Day.new(channel: @channel, date: date, style: message_list_style(cookies)) %>
               <%= link_to(date.day, browse_other_day.path) %>
             <% end %>
           <% end %>
@@ -114,7 +114,7 @@
         <div class="panel-body">
           <ul class="list-unstyled other-channel-list">
             <% @other_channels.each do |channel| %>
-              <% browse_other_channel = ChannelBrowse::Day.new(channel: channel, date: @date) %>
+              <% browse_other_channel = ChannelBrowse::Day.new(channel: channel, date: @date, style: message_list_style(cookies)) %>
               <li><%= link_to(channel.name_with_prefix, browse_other_channel.path) %></li>
             <% end %>
           </ul>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -102,7 +102,8 @@
             <% if events.empty? %>
               <%= date.day %>
             <% else %>
-              <% browse_other_day = ChannelBrowse::Day.new(channel: @channel, date: date, style: message_list_style(cookies)) %>
+              <% browse_other_day = @browse_day.dup %>
+              <% browse_other_day.date = date %>
               <%= link_to(date.day, browse_other_day.path) %>
             <% end %>
           <% end %>
@@ -116,7 +117,8 @@
         <div class="panel-body">
           <ul class="list-unstyled other-channel-list">
             <% @other_channels.each do |channel| %>
-              <% browse_other_channel = ChannelBrowse::Day.new(channel: channel, date: @date, style: message_list_style(cookies)) %>
+              <% browse_other_channel = @browse_day.dup %>
+              <% browse_other_channel.channel = channel %>
               <li><%= link_to(channel.name_with_prefix, browse_other_channel.path) %></li>
             <% end %>
           </ul>

--- a/app/views/messages/searches/_message_group.html.erb
+++ b/app/views/messages/searches/_message_group.html.erb
@@ -2,4 +2,4 @@
 
 <h2><%= date.strftime('%F') %></h2>
 
-<%= render('shared/message_list', messages: messages, show_channel: true) %>
+<%= render('shared/message_list', messages: messages, show_channel: true, style: message_list_style(cookies)) %>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,5 +1,5 @@
 <% anchor = m.fragment_id %>
-<% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date, style: message_list_style(cookies)) %>
+<% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date, style: style) %>
 <tr class="message message-type-<%= m.type.downcase %>">
   <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor), id: anchor) %></td>
   <% if show_channel %>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,5 +1,5 @@
 <% anchor = m.fragment_id %>
-<% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
+<% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date, style: message_list_style(cookies)) %>
 <tr class="message message-type-<%= m.type.downcase %>">
   <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor), id: anchor) %></td>
   <% if show_channel %>

--- a/app/views/shared/_message_list.html.erb
+++ b/app/views/shared/_message_list.html.erb
@@ -9,6 +9,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render(partial: 'shared/message', collection: messages, as: :m, locals: { show_channel: show_channel }) %>
+    <%= render(partial: 'shared/message', collection: messages, as: :m, locals: { show_channel: show_channel, style: style }) %>
   </tbody>
 </table>

--- a/vendor/assets/javascripts/js.cookie.js
+++ b/vendor/assets/javascripts/js.cookie.js
@@ -1,0 +1,165 @@
+/*!
+ * JavaScript Cookie v2.1.4
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	var registeredInModuleLoader = false;
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
+		module.exports = factory();
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				// We're using "expires" because "max-age" is not supported by IE
+				attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				var stringifiedAttributes = '';
+
+				for (var attributeName in attributes) {
+					if (!attributes[attributeName]) {
+						continue;
+					}
+					stringifiedAttributes += '; ' + attributeName;
+					if (attributes[attributeName] === true) {
+						continue;
+					}
+					stringifiedAttributes += '=' + attributes[attributeName];
+				}
+				return (document.cookie = key + '=' + value + stringifiedAttributes);
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = parts[0].replace(rdecode, decodeURIComponent);
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api.call(api, key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));


### PR DESCRIPTION
fixes #81 

#81「Cookieを更新するタイミングについて」の「タブのクリック時のみ更新する」のように、1日分のログのページにおいてタブをクリックしてメッセージ一覧のスタイルを切り替えた場合に、指定したスタイルをCookieに保存します。ただし、連続して隣のページを閲覧する場合に不自然にならないように、そのときのスタイル（Cookieに保存されているものと同じとは限らない）を保持する場合もあります。具体的には以下のような挙動です。

* **Cookieから設定を読み込む**
    * ホームページの「チャンネル」タブのフォームから1日分のページを閲覧する場合のリダイレクト先
    * チャンネル一覧の最終発言日時のリンク
    * 月のページにおける1日分のページへのリンク
    * 月のページのおける発言数グラフの棒に設定する1日分のページへのリンク
    * 管理ページ→チャンネル情報ページの最終発言日時（キャッシュ）のリンク
    * 検索結果ページの各メッセージのタイムスタンプ
* **現在のスタイルに合わせる**
    * 1日分のページ内の、各メッセージのタイムスタンプ
        * 上の検索結果ページの各メッセージのタイムスタンプと挙動が異なるので、app/views/shared/_message.html.erbにおいて、どちらのスタイルのURLにするか指定できるようにする仕組みを作った。
    * 1日分のページ内の、別の1日分のページへのリンク
        * 前の日
        * 次の日
        * カレンダー内の日付
        * 他のチャンネル