### PR TITLE
表示するメッセージの種類のチェックボックスのスタイルを修正する

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -110,6 +110,22 @@ table.day-summary {
   }
 }
 
+.message-visibility {
+  th {
+    vertical-align: top;
+  }
+
+  @media (max-width: $screen-xs-max) {
+    .radio-inline, .checkbox-inline {
+      display: block;
+    }
+
+    .radio-inline + .radio-inline, .checkbox-inline + .checkbox-inline {
+      margin-left: 0;
+    }
+  }
+}
+
 table.user-info, table.channel-info {
   td {
     text-align: right;

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -31,7 +31,7 @@
                     <th scope="row">発言数</th>
                     <td><%= @conversation_messages.length %></td>
                   </tr>
-                  <tr>
+                  <tr class="message-visibility">
                     <th scope="row">表示</th>
                     <td>
                       <form>


### PR DESCRIPTION
fixes #82

スマートフォンで見る場合等、画面幅が小さい場合にチェックボックスの左端が揃わない問題を修正します。

修正後の画面：
![修正後の画面。チェックボックスが縦に並べられ、左端が揃っている。](https://cloud.githubusercontent.com/assets/2551173/26276655/4cb89e5c-3db6-11e7-937c-c11bc676913c.png)
