### PR TITLE
IRCボット：バージョンとコミットIDを返す処理の改良

### DIFF
--- a/config/version.rb
+++ b/config/version.rb
@@ -2,6 +2,24 @@
 
 module LogArchiver
   class Application
+    # Log Archiverのバージョン
     VERSION = '0.2.0'
+
+    # バージョンとコミットIDを表す文字列を返す
+    # @return [String]
+    #
+    # コミットID取得時にエラーが発生した場合は、返り値にコミットIDが含まれない。
+    def self.version_and_commit_id
+      commit_id =
+        begin
+          Dir.chdir(root) do
+            `git show -s --format=%H`.strip
+          end
+        rescue
+          ''
+        end
+
+      commit_id.empty? ? VERSION : "#{VERSION} (#{commit_id})"
+    end
   end
 end

--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -49,13 +49,7 @@ module LogArchiver
       OptionParser.new do |opt|
         opt.banner = "使用法: #{opt.program_name} [オプション]"
 
-        commit_id = `git show -s --format=%H`.chomp rescue ''
-        opt.version =
-          if commit_id.empty?
-            Application::VERSION
-          else
-            "#{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
-          end
+        opt.version = Application.version_and_commit_id
 
         opt.summary_indent = ' ' * 2
         opt.summary_width = 24

--- a/lib/ircs/plugins/version.rb
+++ b/lib/ircs/plugins/version.rb
@@ -16,13 +16,7 @@ module LogArchiver
       def initialize(*)
         super
 
-        commit_id = `git show -s --format=%H`.chomp rescue ''
-        @version =
-          if commit_id.empty?
-            "IRC Log Archiver #{Application::VERSION}"
-          else
-            "IRC Log Archiver #{Application::VERSION} (#{`git show -s --format=%H`.chomp})"
-          end
+        @version = Application.version_and_commit_id
       end
 
       def version(m)

--- a/lib/ircs/plugins/version.rb
+++ b/lib/ircs/plugins/version.rb
@@ -16,7 +16,7 @@ module LogArchiver
       def initialize(*)
         super
 
-        @version = Application.version_and_commit_id
+        @version = "IRC Log Archiver #{Application.version_and_commit_id}"
       end
 
       def version(m)


### PR DESCRIPTION
* 古いgit（1.8.3.1で確認）において `git show -s --format=%H` で末尾に複数の改行文字が付くため、表示が崩れる問題を直しました。
* バージョンとコミットIDを求める処理を LogArchiver::Application.version_and_commit_id にまとめました。