### PR TITLE
チャンネルの個別ページの内容を増やす

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -88,13 +88,27 @@ ul, ol {
   text-align: right;
 }
 
-.search-conditions {
+.current-topic, .search-conditions {
   h2 {
     margin: 0;
     border: 0;
     font-size: $font-size-h4;
   }
+}
 
+.current-topic {
+  h2 {
+    margin-bottom: 0.25em;
+  }
+
+  .topic-by {
+    margin-bottom: 0;
+    text-align: right;
+    color: $gray;
+  }
+}
+
+.search-conditions {
   ul {
     margin-bottom: 0;
   }

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -139,6 +139,10 @@ table.user-info, table.channel-info {
   width: 5em;
 }
 
+.message-datetime {
+  width: 6.5em;
+}
+
 table {
   .odd {
     background-color: $table-bg-accent;

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -114,6 +114,29 @@ ul, ol {
   }
 }
 
+.channel-today-yesterday-buttons {
+  // @media 内で @extend は使えないので、やむを得ずbootstrapからコピー
+
+  @media (max-width: $screen-xs-max) {
+    .btn-responsible {
+      display: block;
+      width: 100%;
+    }
+
+    // Vertically space out multiple block buttons
+    .btn-responsible + .btn-responsible {
+      margin-top: 10px;
+    }
+  }
+
+  @media (min-width: $screen-sm-min) {
+    .btn-responsible {
+      // line-height: ensure proper height of button next to small input
+      @include button-size($padding-small-vertical, $padding-small-horizontal, $font-size-small, $line-height-small, $btn-border-radius-small);
+    }
+  }
+}
+
 table.day-summary {
   background-color: transparent;
 

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -9,6 +9,12 @@ class ChannelsController < ApplicationController
     @channel = Channel.friendly.find(params[:id])
     @channels = Channel.order_for_list
 
+    @latest_topic = Topic.
+      where(channel: @channel).
+      order(timestamp: :desc).
+      limit(1).
+      first
+
     @years = MessageDate.
       uniq.
       where(channel: @channel).

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -12,13 +12,13 @@ class ChannelsController < ApplicationController
     @browse_today = ChannelBrowse::Day.today(@channel)
     today_range = (@browse_today.date)...(@browse_today.date.next_day)
     @todays_speeches_count = ConversationMessage.
-      where(timestamp: today_range).
+      where(channel: @channel, timestamp: today_range).
       count
 
     @browse_yesterday = ChannelBrowse::Day.yesterday(@channel)
     yesterday_range = (@browse_yesterday.date)...(@browse_yesterday.date.next_day)
     @yesterdays_speeches_count = ConversationMessage.
-      where(timestamp: yesterday_range).
+      where(channel: @channel, timestamp: yesterday_range).
       count
 
     @latest_topic = Topic.

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -9,6 +9,18 @@ class ChannelsController < ApplicationController
     @channel = Channel.friendly.find(params[:id])
     @channels = Channel.order_for_list
 
+    @browse_today = ChannelBrowse::Day.today(@channel)
+    today_range = (@browse_today.date)...(@browse_today.date.next_day)
+    @todays_speeches_count = ConversationMessage.
+      where(timestamp: today_range).
+      count
+
+    @browse_yesterday = ChannelBrowse::Day.yesterday(@channel)
+    yesterday_range = (@browse_yesterday.date)...(@browse_yesterday.date.next_day)
+    @yesterdays_speeches_count = ConversationMessage.
+      where(timestamp: yesterday_range).
+      count
+
     @latest_topic = Topic.
       where(channel: @channel).
       order(timestamp: :desc).

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -15,6 +15,12 @@ class ChannelsController < ApplicationController
       limit(1).
       first
 
+    @latest_speeches = ConversationMessage.
+      where(channel: @channel).
+      order(timestamp: :desc).
+      limit(3).
+      reverse
+
     @years = MessageDate.
       uniq.
       where(channel: @channel).

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -26,9 +26,9 @@
               </div>
             <% end %>
 
-            <p>
-              <%= link_to("今日のログ（#{@todays_speeches_count} 発言）", @browse_today.path, class: 'btn btn-sm btn-success') %>
-              <%= link_to("昨日のログ（#{@yesterdays_speeches_count} 発言）", @browse_yesterday.path, class: 'btn btn-sm btn-default') %>
+            <p class="channel-today-yesterday-buttons">
+              <%= link_to("今日のログ（#{@todays_speeches_count} 発言）", @browse_today.path, class: 'btn btn-responsible btn-success') %>
+              <%= link_to("昨日のログ（#{@yesterdays_speeches_count} 発言）", @browse_yesterday.path, class: 'btn btn-responsible btn-default') %>
             </p>
 
             <% unless @latest_speeches.empty? %>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -26,6 +26,11 @@
               </div>
             <% end %>
 
+            <% unless @latest_speeches.empty? %>
+              <h2>最新の発言</h2>
+              <%= render('shared/message_with_datetime_list', messages: @latest_speeches, show_channel: false) %>
+            <% end %>
+
             <h2>年別のログ</h2>
             <ul>
               <% @years.each do |year| %>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -17,6 +17,16 @@
               <h1><%= @channel.name_with_prefix %></h1>
             </div>
 
+            <% if @latest_topic %>
+              <div class="current-topic well">
+                <h2>トピック</h2>
+                <p><%= raw(linkify(@latest_topic.message)) %></p>
+                <% browse_topic_day = ChannelBrowse::Day.new(channel: @channel, date: @latest_topic.timestamp.to_date) %>
+                <p class="topic-by"><small>[<%= link_to("#{@latest_topic.timestamp.strftime('%F %T') } に #{@latest_topic.nick} が設定", browse_topic_day.path(anchor: @latest_topic.fragment_id)) %></small>]</p>
+              </div>
+            <% end %>
+
+            <h2>年別のログ</h2>
             <ul>
               <% @years.each do |year| %>
                 <% browse_year = ChannelBrowse::Year.new(channel: @channel, year: year) %>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -26,6 +26,11 @@
               </div>
             <% end %>
 
+            <p>
+              <%= link_to("今日のログ（#{@todays_speeches_count} 発言）", @browse_today.path, class: 'btn btn-sm btn-success') %>
+              <%= link_to("昨日のログ（#{@yesterdays_speeches_count} 発言）", @browse_yesterday.path, class: 'btn btn-sm btn-default') %>
+            </p>
+
             <% unless @latest_speeches.empty? %>
               <h2>最新の発言</h2>
               <%= render('shared/message_with_datetime_list', messages: @latest_speeches, show_channel: false) %>

--- a/app/views/shared/_message_with_datetime.html.erb
+++ b/app/views/shared/_message_with_datetime.html.erb
@@ -1,0 +1,48 @@
+<% anchor = m.fragment_id %>
+<% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
+<tr class="message message-type-<%= m.type.downcase %>">
+  <td class="message-datetime"><%= link_to(m.timestamp.strftime('%F %T'), browse_day.path(anchor: anchor), id: anchor) %></td>
+  <% if show_channel %>
+    <td class="message-channel"><%= link_to(m.channel.name_with_prefix, channels_path(m.channel)) %></td>
+  <% end %>
+  <% case m %>
+  <% when Join %>
+    <td class="message-content">
+      <b class="nickname"><%= m.nick %></b><%= m.irc_user ? " (#{m.irc_user.user_host})" : '' %> が <b class="channel"><%= m.channel.name_with_prefix %></b> に参加しました。
+    </td>
+  <% when Part %>
+    <td class="message-content">
+      <b class="nickname"><%= m.nick %></b> が <b class="channel"><%= m.channel.name_with_prefix %></b> から退出しました<%= message_or_period(m) %>
+    </td>
+  <% when Quit %>
+    <td class="message-content">
+      <b class="nickname"><%= m.nick %></b> が切断されました<%= message_or_period(m) %>
+    </td>
+  <% when Nick %>
+    <td class="message-content">
+      <b class="nickname old-nickname"><%= m.nick %></b> &rarr; <b class="nickname new-nickname"><%= m.new_nick %></b>
+    </td>
+  <% when Kick %>
+    <td class="message-content">
+      <b class="nickname kick-by"><%= m.nick %></b> が <b class="channel"><%= m.channel.name_with_prefix %></b> から <b class="nickname kick-target"><%= m.target %></b> を退出させました<%= message_or_period(m) %>
+    </td>
+  <% when Topic %>
+    <td class="message-content">
+      <b class="nickname"><%= m.nick %></b> が <b class="channel"><%= m.channel.name_with_prefix %></b> のトピックを設定しました：<%= raw(linkify(m.message)) %>
+    </td>
+  <% when Privmsg %>
+    <td class="message-content">
+      <dl class="message">
+        <dt><b class="nickname message-privmsg"><%= m.nick %></b></dt>
+        <dd><%= raw(linkify(m.message)) %></dd>
+      </dl>
+    </td>
+  <% when Notice %>
+    <td class="message-content">
+      <dl class="message">
+        <dt><b class="nickname"><%= m.nick %></b></dt>
+        <dd><%= raw(linkify(m.message)) %></dd>
+      </dl>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/shared/_message_with_datetime_list.html.erb
+++ b/app/views/shared/_message_with_datetime_list.html.erb
@@ -1,0 +1,14 @@
+<table class="table table-striped message-list">
+  <thead>
+    <tr>
+      <th class="message-datetime">日時</th>
+      <% if show_channel %>
+        <th class="message-channel">チャンネル</th>
+      <% end %>
+      <th>メッセージ</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render(partial: 'shared/message_with_datetime', collection: messages, as: :m, locals: { show_channel: show_channel }) %>
+  </tbody>
+</table>


### PR DESCRIPTION
これまでログのある年の一覧のみだったチャンネルの個別ページに以下のものを加えました。

* 現在のトピック（トピックが記録されている場合のみ）
* 今日・昨日のログに移動するボタン
* 最新の3発言（発言が記録されている場合のみ）