### PR TITLE
PRIVMSG・NOTICEでメッセージが空白文字のみの場合を許可する

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,5 +1,5 @@
 class Notice < ConversationMessage
-  validates :message, presence: true
+  validates :message, length: { minimum: 1 }
 
   # Tiarra のログ形式の文字列を返す
   # @return [String]

--- a/app/models/privmsg.rb
+++ b/app/models/privmsg.rb
@@ -1,5 +1,5 @@
 class Privmsg < ConversationMessage
-  validates :message, presence: true
+  validates :message, length: { minimum: 1 }
 
   # Tiarra のログ形式の文字列を返す
   # @return [String]

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -11,12 +11,15 @@ class NoticeTest < ActiveSupport::TestCase
 
   test 'message は必須' do
     @notice.message = nil
-    refute(@notice.valid?)
+    refute(@notice.valid?, 'nilは無効')
+
+    @notice.message = ''
+    refute(@notice.valid?, '空文字列は無効')
   end
 
-  test 'message は空白のみではならない' do
-    @notice.message = ' ' * 10
-    refute(@notice.valid?)
+  test 'message は空白のみでもよい' do
+    @notice.message = ' 　' * 10
+    assert(@notice.valid?)
   end
 
   test 'Tiarra のログ形式が正しい' do

--- a/test/models/privmsg_test.rb
+++ b/test/models/privmsg_test.rb
@@ -11,12 +11,15 @@ class PrivmsgTest < ActiveSupport::TestCase
 
   test 'message は必須' do
     @privmsg.message = nil
-    refute(@privmsg.valid?)
+    refute(@privmsg.valid?, 'nilは無効')
+
+    @privmsg.message = ''
+    refute(@privmsg.valid?, '空文字列は無効')
   end
 
-  test 'message は空白のみではならない' do
-    @privmsg.message = ' ' * 10
-    refute(@privmsg.valid?)
+  test 'message は空白のみでもよい' do
+    @privmsg.message = ' 　' * 10
+    assert(@privmsg.valid?)
   end
 
   test 'Tiarra のログ形式が正しい' do


### PR DESCRIPTION
fixes #90

空行を記録できるようにPRIVMSG・NOTICEでメッセージが空白文字のみの場合を許可するようにしました。