### PR TITLE
ConversationMessages: irc_user_idの再作成

### DIFF
--- a/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
+++ b/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
@@ -1,0 +1,30 @@
+class RecreateConversationMessagesIrcUserId < ActiveRecord::Migration
+  def up
+    puts('[irc_user_id の退避]')
+    id_irc_user_id_pairs = {}
+    ConversationMessage.where.not(irc_user_id: 0).find_each do |cm|
+      id_irc_user_id_pairs[cm.irc_user_id] ||= []
+      id_irc_user_id_pairs[cm.irc_user_id] << cm.id
+    end
+
+    puts
+    puts('[テーブルの変更]')
+    change_table :conversation_messages do |t|
+      t.remove :irc_user_id
+      t.integer :irc_user_id, null: false, default: 0
+    end
+
+    puts
+    puts('[irc_user_id の復元]')
+    id_irc_user_id_pairs.each do |irc_user_id, cm_ids|
+      ConversationMessage.where(id: cm_ids).update_all(irc_user_id: irc_user_id)
+    end
+
+    puts
+    puts('[irc_user_id のインデックスの再構築]')
+    add_index :conversation_messages, :irc_user_id
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170408163604) do
+ActiveRecord::Schema.define(version: 20170617130524) do
 
   create_table "channel_last_speeches", force: :cascade, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "channel_id",              limit: 4
@@ -37,13 +37,13 @@ ActiveRecord::Schema.define(version: 20170408163604) do
 
   create_table "conversation_messages", force: :cascade, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "channel_id",  limit: 4
-    t.integer  "irc_user_id", limit: 4
     t.datetime "timestamp",                              null: false
     t.string   "nick",        limit: 64,    default: "", null: false
     t.text     "message",     limit: 65535
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.string   "type",        limit: 255
+    t.integer  "irc_user_id", limit: 4,     default: 0,  null: false
   end
 
   add_index "conversation_messages", ["channel_id", "timestamp"], name: "index_conversation_messages_on_channel_id_and_timestamp", using: :btree


### PR DESCRIPTION
TiarraのログのPRIVMSG等の会話のメッセージでは、ユーザーの識別に使える情報がニックネーム以外含まれていません。そのため、過去のIRCログをデータベースに追加する際、ユーザー名やホストを格納するためのIrcUserを指定しない（irc_user_idをNULLにする）ようにしていました。しかし、このようにするとSQLでUPDATEを実行するときにirc_user_id列に対して `Incorrect integer value: ''` というエラーが出て止まってしまうことが分かりました。

これを防ぐため、conversation_messagesテーブルのirc_user_id列を作り直し、NULLを不許可、既定値を0に設定しました。IrcUserのidはオートインクリメントにより必ず1以上となるため、conversation_messages.irc_user_idを0にしておけば、従来通り対応するIrcUserがないことを表せます。

マイグレーションの際は、マイグレーション前のirc_user_idを保存し、テーブル変更後に復元するようにしています。