### PR TITLE
ログ検索結果ページのチャンネルへのリンクのURLを修正する 

### DIFF
--- a/app/models/message_search.rb
+++ b/app/models/message_search.rb
@@ -133,7 +133,7 @@ class MessageSearch
   def set_attributes_with_result_page_params(params)
     self.query = params['q']
     self.nick = params['nick']
-    self.channels = params['channels'].split(' ')
+    self.channels = params['channels']&.split(' ') || []
     self.since = params['since']
     self.until = params['until']
     self.page = params['page']

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -3,7 +3,7 @@
 <tr class="message message-type-<%= m.type.downcase %>">
   <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor), id: anchor) %></td>
   <% if show_channel %>
-    <td class="message-channel"><%= link_to(m.channel.name_with_prefix, channels_path(m.channel)) %></td>
+    <td class="message-channel"><%= link_to(m.channel.name_with_prefix, m.channel) %></td>
   <% end %>
   <% case m %>
   <% when Join %>

--- a/app/views/shared/_message_with_datetime.html.erb
+++ b/app/views/shared/_message_with_datetime.html.erb
@@ -3,7 +3,7 @@
 <tr class="message message-type-<%= m.type.downcase %>">
   <td class="message-datetime"><%= link_to(m.timestamp.strftime('%F %T'), browse_day.path(anchor: anchor), id: anchor) %></td>
   <% if show_channel %>
-    <td class="message-channel"><%= link_to(m.channel.name_with_prefix, channels_path(m.channel)) %></td>
+    <td class="message-channel"><%= link_to(m.channel.name_with_prefix, m.channel) %></td>
   <% end %>
   <% case m %>
   <% when Join %>

--- a/test/integration/messages_search_test.rb
+++ b/test/integration/messages_search_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class MessagesSearchTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:setting)
+
+    ConversationMessage.delete_all
+    @privmsg = create(:privmsg)
+  end
+
+  teardown do
+    ConversationMessage.delete_all
+  end
+
+  test '検索結果が正しく表示される' do
+    get(
+      messages_search_path,
+      q: 'メッセージ'
+    )
+    assert_response(:success)
+
+    assert_select('h2', '2016-04-01', '日付の見出しが存在する')
+
+    # 検索結果が1件のみ
+    assert_select('.message-type-privmsg', 1)
+
+    assert_select('.message-type-privmsg') do
+      assert_select('dt', 'rgrb', 'ニックネームが正しい')
+      assert_select('dd', 'プライベートメッセージ', 'メッセージが正しい')
+    end
+
+    channel = css_select('.message-type-privmsg > .message-channel').first
+    refute_nil(channel, 'チャンネル欄が存在する')
+
+    assert_equal('#irc_test', channel.content, 'チャンネルの表示が正しい')
+
+    link_for_channel = channel.at_css('a')
+    refute_nil(link_for_channel, 'チャンネルへのリンクが存在する')
+
+    assert_equal('/channels/irc_test', link_for_channel['href'], 'チャンネルへのリンクのリンク先が正しい')
+  end
+end


### PR DESCRIPTION
#94「検索結果一覧ページのチャンネルに設定されたリンクが間違っている」の修正です。

`link_to` で誤って `channels_path`（チャンネル一覧ページのパス）を指定していた箇所を直しました。Channelのインスタンスを渡すとそのチャンネルの個別ページのパス（→ChannelsController#showに渡る）になります。

また、チャンネルへのリンクが正しいか確認する項目を含む、検索結果ページの表示テストを追加しました。