### PR TITLE
前後のページのメタ情報を設定する

### DIFF
--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -1,4 +1,6 @@
 class Channels::DaysController < ApplicationController
+  include NavLinkSettable
+
   def index
     target_channels, @other_channels = Channel.
       order_for_list.
@@ -15,6 +17,9 @@ class Channels::DaysController < ApplicationController
                                             month: @month)
     @browse_prev_month = browse_month.prev_month
     @browse_next_month = browse_month.next_month
+
+    set_prev_link!(@browse_prev_month)
+    set_next_link!(@browse_next_month)
 
     start_date = Date.new(@year, @month, 1)
     date_range = start_date...(start_date.next_month)
@@ -79,6 +84,9 @@ class Channels::DaysController < ApplicationController
       (params[:style] == 'raw') ? @browse_day_raw : @browse_day_normal
     @browse_prev_day = @browse_day.prev_day
     @browse_next_day = @browse_day.next_day
+
+    set_prev_link!(@browse_prev_day)
+    set_next_link!(@browse_next_day)
 
     whole_messages =
       if @browse_day.is_style_raw?

--- a/app/controllers/channels/months_controller.rb
+++ b/app/controllers/channels/months_controller.rb
@@ -1,4 +1,6 @@
 class Channels::MonthsController < ApplicationController
+  include NavLinkSettable
+
   def index
     target_channels, @other_channels = Channel.
       order_for_list.
@@ -10,6 +12,9 @@ class Channels::MonthsController < ApplicationController
     browse_year = ChannelBrowse::Year.new(channel: @channel, year: @year)
     @browse_prev_year = browse_year.prev_year
     @browse_next_year = browse_year.next_year
+
+    set_prev_link!(@browse_prev_year)
+    set_next_link!(@browse_next_year)
 
     start_date = Date.new(@year, 1, 1)
     @month_count = MessageDate.

--- a/app/controllers/concerns/nav_link_settable.rb
+++ b/app/controllers/concerns/nav_link_settable.rb
@@ -3,29 +3,44 @@ module NavLinkSettable
   extend ActiveSupport::Concern
 
   # 前のページへのリンクのメタ情報を設定する
-  # @param [#path] browse_prev 前のページの閲覧
+  # @param [String, #path] href 前のページ
+  # @return [void]
   #
-  # browse_prev が偽の場合は何もしない。
-  def set_prev_link!(browse_prev)
-    set_nav_link!(:prev, browse_prev)
+  # href が偽の場合は何もしない。
+  def set_prev_link!(href)
+    set_nav_link!(:prev, href)
   end
 
   # 次のページへのリンクのメタ情報を設定する
-  # @param [#path] browse_next 次のページの閲覧
+  # @param [String, #path] href 次のページ
+  # @return [void]
   #
-  # browse_next が偽の場合は何もしない。
-  def set_next_link!(browse_next)
-    set_nav_link!(:next, browse_next)
+  # href が偽の場合は何もしない。
+  def set_next_link!(href)
+    set_nav_link!(:next, href)
   end
 
   private
 
   # リンクのメタ情報を設定する
   # @param [Symbol] type リンクの種類
-  # @param [#path] browse ページの閲覧
+  # @param [String, #path] href リンク先
+  # @return [void]
   #
-  # browse 偽の場合は何もしない。
-  def set_nav_link!(type, browse)
-    set_meta_tags(type => browse.path) if browse
+  # href が偽の場合は何もしない。
+  def set_nav_link!(type, href)
+    return unless href
+
+    path =
+      case href
+      when String
+        href
+      when ->x { x.respond_to?(:path) }
+        href.path
+      else
+        raise ArgumentError, "could not linkify: #{href}"
+      end
+
+    set_meta_tags(type => path)
   end
 end

--- a/app/controllers/concerns/nav_link_settable.rb
+++ b/app/controllers/concerns/nav_link_settable.rb
@@ -1,0 +1,31 @@
+# prev・nextといったナビゲーション用のメタ情報の設定が行えるモジュール
+module NavLinkSettable
+  extend ActiveSupport::Concern
+
+  # 前のページへのリンクのメタ情報を設定する
+  # @param [#path] browse_prev 前のページの閲覧
+  #
+  # browse_prev が偽の場合は何もしない。
+  def set_prev_link!(browse_prev)
+    set_nav_link!(:prev, browse_prev)
+  end
+
+  # 次のページへのリンクのメタ情報を設定する
+  # @param [#path] browse_next 次のページの閲覧
+  #
+  # browse_next が偽の場合は何もしない。
+  def set_next_link!(browse_next)
+    set_nav_link!(:next, browse_next)
+  end
+
+  private
+
+  # リンクのメタ情報を設定する
+  # @param [Symbol] type リンクの種類
+  # @param [#path] browse ページの閲覧
+  #
+  # browse 偽の場合は何もしない。
+  def set_nav_link!(type, browse)
+    set_meta_tags(type => browse.path) if browse
+  end
+end

--- a/app/controllers/messages/searches_controller.rb
+++ b/app/controllers/messages/searches_controller.rb
@@ -1,4 +1,16 @@
+# メッセージの検索についてのコントローラ
 class Messages::SearchesController < ApplicationController
+  # 前後の検索結果ページのパスの生成等に使用する
+  include Kaminari::Helpers::HelperMethods
+  # ナビゲーション用のメタ情報を
+  include NavLinkSettable
+
+  # 検索クエリを作成する
+  #
+  # 有効なクエリならば #show で検索結果ページを表示するようにリダイレクト
+  # する。
+  #
+  # 無効なクエリならばホームページの検索フォームが見えるように描画する。
   def create
     @message_search = MessageSearch.new(params_for_create)
     @channel_browse = ChannelBrowse.new
@@ -13,6 +25,12 @@ class Messages::SearchesController < ApplicationController
     end
   end
 
+  # 検索結果ページを表示する
+  #
+  # 有効なクエリならばデータベースから検索して結果を表示する。
+  # ナビゲーション用のメタ情報も検索結果から用意する。
+  #
+  # 無効なクエリならばホームページの検索フォームが見えるように描画する。
   def show
     @message_search = MessageSearch.new
     @message_search.set_attributes_with_result_page_params(params_for_show)
@@ -21,6 +39,10 @@ class Messages::SearchesController < ApplicationController
 
     if @message_search.valid?
       @result = @message_search.result
+
+      @messages = @result.messages
+      set_prev_link!(path_to_prev_page(@messages))
+      set_next_link!(path_to_next_page(@messages))
     else
       @invalid_model = :message_search
       render 'welcome/index'
@@ -29,6 +51,8 @@ class Messages::SearchesController < ApplicationController
 
   private
 
+  # create で使用できるパラメータを返す
+  # @return [ActionController::Parameters]
   def params_for_create
     result = params.
       require(:message_search).
@@ -40,6 +64,8 @@ class Messages::SearchesController < ApplicationController
     result
   end
 
+  # show で使用できるパラメータを返す
+  # @return [ActionController::Parameters]
   def params_for_show
     params.permit(:q, :nick, :channels, :since, :until, :page)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,7 @@ module ApplicationHelper
   end
 
   # 既定の meta タグの内容を返す
+  # @return [Hash]
   def default_meta_tags
     {
       site: site_title,

--- a/app/views/messages/searches/show.html.erb
+++ b/app/views/messages/searches/show.html.erb
@@ -33,11 +33,11 @@
             </ul>
           </div>
 
-          <p><%= page_entries_info(@result.messages) %></p>
+          <p><%= page_entries_info(@messages) %></p>
 
           <%= render(partial: 'message_group', collection: @result.message_groups.to_a) %>
 
-          <%= paginate(@result.messages, outer_window: 2) %>
+          <%= paginate(@messages, outer_window: 2) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
「前へ」「次へ」のリンクがあるページに `<link rel="prev" />` や `<link rel="next" />` のタグを追加します。対応しているブラウザやブラウザの拡張機能を使うと、隣接しているページが閲覧しやすくなります。

例：FirefoxまたはChromeで[Vimium](https://github.com/philc/vimium)拡張機能を使うと、<kbd>[[</kbd> で前のページに、<kbd>]]</kbd> で次のページにすぐに飛べる。