### PR TITLE
Travis CIでMroongaのインストールに失敗する問題を修正する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.3
+  # テストで使用するRubyのバージョンを指定する
+  # 最新版とそのひとつ前のバージョンで試す
   - 2.3.4
-  - 2.4.0
+  - 2.3.5
   - 2.4.1
+  - 2.4.2
 services:
   - mysql
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ env:
   global:
     - TZ=Asia/Tokyo
 before_install:
-  - curl --silent --location https://github.com/groonga/groonga/raw/master/data/travis/setup.sh | sh
-  - sudo apt-get install -y -V mysql-server-mroonga
+  - ./install-mroonga-on-travis-ci.sh
 before_script:
   - cp config/database.yml.travis config/database.yml
   - mysql -u root -e 'SET GLOBAL innodb_file_format = Barracuda'

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,7 +1,7 @@
 test:
   adapter: mysql2
   database: log_archiver_test
-  username: travis
+  username: root
   encoding: utf8mb4
   charset: utf8mb4
   collation: utf8mb4_general_ci

--- a/install-mroonga-on-travis-ci.sh
+++ b/install-mroonga-on-travis-ci.sh
@@ -26,3 +26,4 @@ sudo rm -rf /var/{lib,log}/mysql
 
 # Mroongaをインストールする
 sudo apt-get install -y -V mysql-server-mroonga
+sudo apt-get install -y -V libmysqlclient-dev

--- a/install-mroonga-on-travis-ci.sh
+++ b/install-mroonga-on-travis-ci.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
 
-# Enable the universe repository and the security update repository to install Mroonga
-sudo apt install -y -V software-properties-common lsb-release
+# Travis CIでMroongaをインストールするためのスクリプト
+#
+# 参考文献：
+# 1. [Mroonga v7.08 documentation » 2.4. Ubuntu](http://mroonga.org/ja/docs/install/ubuntu.html)
+# 2. [Install MySQL 5.7 on Travis-CI](https://gist.github.com/BenMorel/d981f25ead0926a0cb6d)
+
+# Mroongaのインストールに必要なuniverseリポジトリと
+# セキュリティアップデートリポジトリを有効にする
+sudo apt-get install -y -V software-properties-common lsb-release
 sudo add-apt-repository -y universe
 sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu $(lsb_release --short --codename)-security main restricted"
 
-# Add the ppa:groonga/ppa PPA to the system
+# ppa:groonga/ppa PPAをシステムに追加する
 sudo add-apt-repository -y ppa:groonga/ppa
-sudo apt update
+sudo apt-get update
 
-# Install Mroonga for MySQL
-sudo apt install -y -V mysql-server-mroonga
+# Travis CIのVMのUbuntu 14.04では、標準でMySQL 5.6がインストール
+# されているが、これはMySQL 5.5ベースのmysql-server-mroongaと共存できない。
+# そのため、最初にMySQL 5.6に関連したパッケージを除く。
+sudo apt-get remove --purge "^mysql.*"
+sudo apt-get autoremove
+sudo apt-get autoclean
+sudo rm -rf /var/{lib,log}/mysql
+
+# Mroongaをインストールする
+sudo apt-get install -y -V mysql-server-mroonga

--- a/install-mroonga-on-travis-ci.sh
+++ b/install-mroonga-on-travis-ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Enable the universe repository and the security update repository to install Mroonga
+sudo apt install -y -V software-properties-common lsb-release
+sudo add-apt-repository -y universe
+sudo add-apt-repository "deb http://security.ubuntu.com/ubuntu $(lsb_release --short --codename)-security main restricted"
+
+# Add the ppa:groonga/ppa PPA to the system
+sudo add-apt-repository -y ppa:groonga/ppa
+sudo apt update
+
+# Install Mroonga for MySQL
+sudo apt install -y -V mysql-server-mroonga


### PR DESCRIPTION
Travis CIでMroongaのインストールに失敗していたため、しばらくテストができていませんでしたが、インストール手順を見直して成功するように修正しました。

原因は「[Build Environment Update History - Travis CI](https://docs.travis-ci.com/user/build-environment-updates/2016-12-02/)」で書かれている、2016-12-02からTravis CIでMySQL 5.6が使われるようになったことでした。Mroonga公式が配布しているmysql-server-mroongaパッケージがMySQL 5.5ベースだったため、バージョンが競合してインストールできなくなっていました。