### PR TITLE
Chart.js: 読み込むファイル名をChart.min.jsに変更する

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 //= require moment/ja
 //= require bootstrap-datetimepicker
 //= require ./datetimepicker
-//= require Chart
+//= require Chart.min
 //= require log_archiver
 //= require message_list_style
 //= require_tree .


### PR DESCRIPTION
fixes #101