### PR TITLE
IRC ボットの QUIT メッセージを設定ファイルで変えられるようにした

### DIFF
--- a/config/ircbot.yml.example
+++ b/config/ircbot.yml.example
@@ -10,6 +10,8 @@ development:
     RealName: LogArchiver
     Channels:
       - ''
+    # QUIT メッセージ。空にすると "Caught <signal>" が設定される
+    QuitMessage: 'bye'
   # IRC管理・運営サービス(Atheme-Services) の設定
   AuthenticationServer:
     # NickServ(Atheme-Services) の XMLRPC アドレス

--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -30,6 +30,7 @@ module LogArchiver
 
       bot = new_bot(config, plugins, log_level)
 
+      @quit_message = config.irc_bot['QuitMessage']
       set_signal_handler(bot)
       bot.start
 
@@ -200,7 +201,7 @@ module LogArchiver
       %i(SIGINT SIGTERM).each do |signal|
         Signal.trap(signal) do
           Thread.new(signal) do |sig|
-            bot.quit("Caught #{sig}")
+            bot.quit(@quit_message.empty? ? "Caught #{sig}" : @quit_message)
           end
         end
       end


### PR DESCRIPTION
稼働中のボットの切断メッセージにシステムシグナルが出て欲しくなかったため、設定ファイルで任意の文字列を設定できるようにしました。
IRC ボットの設定ファイルが変更されます。