### PR TITLE
create_tableで指定されたoptionsが無視される問題を修正する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ before_script:
   - mysql -u root -e 'SET GLOBAL innodb_file_per_table = 1'
   - mysql -u root -e 'SET GLOBAL innodb_large_prefix = 1'
   - mysql -e 'CREATE DATABASE IF NOT EXISTS log_archiver_test;'
-  - bundle exec bin/rails db:setup
-script: bundle exec bin/rails test
 after_success:
   - bundle exec codeclimate-test-reporter
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'xmlrpc'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 5.0.0'
 # Use mysql as the database for Active Record
-gem 'mysql2', '>= 0.3.13', '< 0.5'
+gem 'mysql2', '~> 0.5.2'
 #gem 'activerecord-mysql-awesome'
 #gem 'activerecord-mysql-comment'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.10)
+    mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.8.4)
@@ -320,7 +320,7 @@ DEPENDENCIES
   meta-tags
   minitest-reporters
   momentjs-rails (~> 2.15)
-  mysql2 (>= 0.3.13, < 0.5)
+  mysql2 (~> 0.5.2)
   pry-rails
   rails (>= 5.0.0)
   rails-controller-testing

--- a/config/initializers/ar_innodb_row_format.rb
+++ b/config/initializers/ar_innodb_row_format.rb
@@ -1,13 +1,24 @@
 # create_table メソッドで 'ROW_FORMAT=DYNAMIC' が
 # デフォルトで指定されるようにする
 # @see http://qiita.com/kamipo/items/101aaf8159cf1470d823
+#
 # Rails5 では alias_method_chain が非推奨になったため変更
 # @see https://qiita.com/horipori/items/3b1965abcd0d61f1108c
 ActiveSupport.on_load :active_record do
   module ActiveRecord::ConnectionAdapters
     module CreateTableWithInnodbRowFormat
+      ROW_FORMAT_DYNAMIC = 'ROW_FORMAT=DYNAMIC'.freeze
+
       def create_table(table_name, options = {})
-        table_options = options.merge(options: 'ROW_FORMAT=DYNAMIC')
+        old_options = options[:options]
+        new_options =
+          if old_options
+            "#{old_options} #{ROW_FORMAT_DYNAMIC}"
+          else
+            ROW_FORMAT_DYNAMIC
+          end
+        table_options = options.merge(options: new_options)
+
         super(table_name, table_options) do |td|
           yield td if block_given?
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170617130524) do
+ActiveRecord::Schema.define(version: 20170704121029) do
 
   create_table "channel_last_speeches", force: :cascade, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC" do |t|
     t.integer  "channel_id"


### PR DESCRIPTION
fixes #116 

データベース準備時のテーブル作成で失敗する問題を修正しました。

`create_table(テーブル名, options: テーブル作成時オプション)` で生成されるSQL文 `CREATE TABLE` の末尾に追加される `ENGINE=Mroonga` が上書きされて、Mroongaの全文検索機能が使えなくなっていることが原因でした。