### PR TITLE
IRC ボットを SSL 接続対応にしてみた

### DIFF
--- a/config/ircbot.yml.example
+++ b/config/ircbot.yml.example
@@ -10,6 +10,7 @@ development:
     RealName: LogArchiver
     Channels:
       - ''
+    SSL: off
     # QUIT メッセージ。空にすると "Caught <signal>" が設定される
     QuitMessage: 'bye'
   # IRC管理・運営サービス(Atheme-Services) の設定

--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -172,6 +172,8 @@ module LogArchiver
           c.realname = bot_config['RealName']
           c.channels = bot_config['Channels'] || []
 
+          c.ssl.use = bot_config['SSL']
+
           c.plugins.plugins = plugins
           c.plugins.options = plugin_options
         end


### PR DESCRIPTION
ウェブインターフェイスはリバースプロキシによって SSL 対応になっていますが、IRC ボットは平文接続詞か出来ないようになっていました。
そのため、IRC ボットも SSL 接続できるようにしました。