### PR TITLE
MySQL 5.7.5以降でONLY_FULL_GROUP_BYが既定で有効になることへの対応

### DIFF
--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -40,7 +40,8 @@ class Channels::DaysController < ApplicationController
     year_month_list = MessageDate.year_month_list(@channel)
     @years = year_month_list.
       map { |year, _| year }.
-      distinct
+      # mapにより配列が返るため、distinctでなくuniqを使う
+      uniq
     @year_months_in_the_year =
       year_month_list.select { |year, _| year == @year }
   end

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -16,6 +16,8 @@ default: &default
   collation: utf8mb4_general_ci
   pool: 5
   socket: /var/lib/mysql/mysql.sock
+  variables:
+    sql_mode: TRADITIONAL
 
 development:
   <<: *default

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -5,3 +5,5 @@ test:
   encoding: utf8mb4
   charset: utf8mb4
   collation: utf8mb4_general_ci
+  variables:
+    sql_mode: TRADITIONAL


### PR DESCRIPTION
MySQL 5.7.5以降を使う場合、Rails 5では `SELECT DISTINCT` と `ORDER BY` を組み合わせるときにエラーが発生します。主に 8ae679d でこの問題を修正しました。