### PR TITLE
Arel.sql を使わない形に書き換えた

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -36,7 +36,11 @@ class ChannelsController < ApplicationController
     @years = MessageDate.
       distinct.
       where(channel: @channel).
-      pluck(Arel.sql('YEAR(date)'))
+      pluck('date').
+      map do |date|
+        date.year
+      end.
+      uniq
   end
 
   def new

--- a/app/models/message_date.rb
+++ b/app/models/message_date.rb
@@ -10,7 +10,11 @@ class MessageDate < ApplicationRecord
     where(channel: channel).
       distinct.
       order(:date).
-      pluck(Arel.sql('YEAR(date)'))
+      pluck('date').
+      map do |date|
+        date.year
+      end.
+      uniq
   end
 
   # 指定したチャンネルのメッセージが存在する年月の配列を返す
@@ -20,6 +24,10 @@ class MessageDate < ApplicationRecord
     where(channel: channel).
       distinct.
       order(:date).
-      pluck(Arel.sql('YEAR(date), MONTH(date)'))
+      pluck('date').
+      map do |date|
+        [date.year, date.month]
+      end.
+      uniq
   end
 end


### PR DESCRIPTION
Rails 5.2 系列では、モデルの order / pluck の引数に生の SQL をそのまま入れることが非推奨になりました(6.0で廃止されるようです)。
そこで、ワーニングメッセージの通り、`Arel.sql` でラップして生の SQL を実行させるようにしました。

しかし、Arel は Rails (ActiveRecord) の内部APIであり、プログラム本体で使用することが勧められておらず、仕様変更になったときも特に注意書は出ないそうです。
[Arelでクエリを書くのはやめた方が良い5つの理由](https://qiita.com/jnchito/items/630b9f038c87298b5756)

log-archiver では、MySQL の関数を使う為に、生 SQL が使われていました。
これをなくすため、データベースからはカラムの値をそのまま得て、ruby 側で必要なデータを加工するようにしました。

より良い方法はないのでしょうか。