### PR TITLE
正規表現の「行頭」「行末」を表すアンカーを文字列の「先頭」「末尾」を表す物に変更

### DIFF
--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <% if name_changeable %>
       <%= f.label(:name) %>
-      <%= f.text_field(:name, class: 'form-control', required: true, pattern: '^[^# ,:]+[^ ,:]*$') %>
+      <%= f.text_field(:name, class: 'form-control', required: true, pattern: '\A[^# ,:]+[^ ,:]*\z') %>
       <p class="help-block"><strong>先頭の "#" を除いた</strong>チャンネル名を入力してください。例：#もの書き → もの書き</p>
       <p class="help-block">作成後にチャンネル名を変更することはできません。</p>
     <% else %>
@@ -13,7 +13,7 @@
 
   <div class="form-group">
     <%= f.label(:identifier) %>
-    <%= f.text_field(:identifier, class: 'form-control', required: true, pattern: '^[A-Za-z][-_A-Za-z0-9]*$') %>
+    <%= f.text_field(:identifier, class: 'form-control', required: true, pattern: '\A[A-Za-z][-_A-Za-z0-9]*\z') %>
     <p class="help-block">識別子に使用可能な文字は半角英数字、ハイフン（<code>-</code>）、アンダーライン（<code>_</code>）です。先頭の文字には英字のみが使用可能です。</p>
   </div>
 

--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <% if name_changeable %>
       <%= f.label(:name) %>
-      <%= f.text_field(:name, class: 'form-control', required: true, pattern: '\A[^# ,:]+[^ ,:]*\z') %>
+      <%= f.text_field(:name, class: 'form-control', required: true, pattern: '^[^# ,:]+[^ ,:]*$') %>
       <p class="help-block"><strong>先頭の "#" を除いた</strong>チャンネル名を入力してください。例：#もの書き → もの書き</p>
       <p class="help-block">作成後にチャンネル名を変更することはできません。</p>
     <% else %>
@@ -13,7 +13,7 @@
 
   <div class="form-group">
     <%= f.label(:identifier) %>
-    <%= f.text_field(:identifier, class: 'form-control', required: true, pattern: '\A[A-Za-z][-_A-Za-z0-9]*\z') %>
+    <%= f.text_field(:identifier, class: 'form-control', required: true, pattern: '^[A-Za-z][-_A-Za-z0-9]*$') %>
     <p class="help-block">識別子に使用可能な文字は半角英数字、ハイフン（<code>-</code>）、アンダーライン（<code>_</code>）です。先頭の文字には英字のみが使用可能です。</p>
   </div>
 

--- a/lib/ircs/plugins/login_nickserv.rb
+++ b/lib/ircs/plugins/login_nickserv.rb
@@ -21,7 +21,7 @@ module LogArchiver
           (?:\.[a-z\d](?:[-a-z\d]{0,61}[a-z\d])?)*)/ix
       # サーバーがネットワークに参加したときのメッセージを表す正規表現
       NETJOIN_RE =
-        /^\*\*\* Notice -- Netjoin #{HOSTNAME_RE} <-> (#{HOSTNAME_RE})/o
+        /\A\*\*\* Notice -- Netjoin #{HOSTNAME_RE} <-> (#{HOSTNAME_RE})/o
 
       # サーバーがネットワークに参加したときのメッセージを表す正規表現
       match(NETJOIN_RE, method: :joined)
@@ -97,7 +97,7 @@ module LogArchiver
           raise e
         end
 
-        m = result.match(/^Logins from: (.+)$/)
+        m = result.match(/\ALogins from: (.+)\z/)
         if(m)
           m[1].split.include?(@bot.nick)
         else

--- a/lib/ircs/plugins/part.rb
+++ b/lib/ircs/plugins/part.rb
@@ -11,7 +11,7 @@ module LogArchiver
       set(plugin_name: 'Part')
 
       self.prefix = '.'
-      match(/part(?:-(\w+))?$/, method: :part)
+      match(/part(?:-(\w+))?\z/, method: :part)
 
       def initialize(*args)
         super


### PR DESCRIPTION
セキュリティホールに繋がりかねないらしいので置き換えてみました。

@see https://qiita.com/jnchito/items/ea7832df6f64a9034872