### PR TITLE
DISTINCTの代わりにGROUP BYを使う

### DIFF
--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Channels::DaysController < ApplicationController
   include NavLinkSettable
 
@@ -28,13 +30,14 @@ class Channels::DaysController < ApplicationController
             date: date_range).
       order(:date).
       pluck(:date)
+
+    sql_date_timestamp = Arel.sql('DATE(timestamp)')
     @speech_count = ConversationMessage.
-      distinct.
       where(channel: @channel,
             type: %w(Privmsg Notice),
             timestamp: date_range).
-      group('DATE(timestamp)').
-      order(:timestamp).
+      group(sql_date_timestamp).
+      order(sql_date_timestamp).
       count
 
     year_month_list = MessageDate.year_month_list(@channel)

--- a/app/controllers/channels/months_controller.rb
+++ b/app/controllers/channels/months_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Channels::MonthsController < ApplicationController
   include NavLinkSettable
 
@@ -17,12 +19,12 @@ class Channels::MonthsController < ApplicationController
     set_next_link!(@browse_next_year)
 
     start_date = Date.new(@year, 1, 1)
+    sql_extract_month_from_date = Arel.sql('EXTRACT(MONTH FROM date)')
     @month_count = MessageDate.
-      distinct.
       where(channel: @channel,
             date: start_date...(start_date.next_year)).
-      group('MONTH(date)').
-      order(:date).
+      group(sql_extract_month_from_date).
+      order(sql_extract_month_from_date).
       count
 
     @years = MessageDate.years(@channel)

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -34,9 +34,10 @@ class ChannelsController < ApplicationController
       reverse
 
     @years = MessageDate.
-      distinct.
       where(channel: @channel).
-      pluck(Arel.sql('YEAR(date)'))
+      group(:year).
+      order(Arel.sql('EXTRACT(YEAR FROM date)')).
+      pluck(Arel.sql('EXTRACT(YEAR FROM date) AS year'))
   end
 
   def new

--- a/app/models/message_date.rb
+++ b/app/models/message_date.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# メッセージが存在する日付のモデル
 class MessageDate < ApplicationRecord
   belongs_to :channel
   validates :channel, presence: true
@@ -8,9 +11,9 @@ class MessageDate < ApplicationRecord
   # @return [Array<Integer>]
   def self.years(channel)
     where(channel: channel).
-      distinct.
-      order(:date).
-      pluck(Arel.sql('YEAR(date)'))
+      group(:year).
+      order(Arel.sql('EXTRACT(YEAR FROM date)')).
+      pluck(Arel.sql('EXTRACT(YEAR FROM date) AS year'))
   end
 
   # 指定したチャンネルのメッセージが存在する年月の配列を返す
@@ -18,8 +21,9 @@ class MessageDate < ApplicationRecord
   # @return [Array<Array<Integer, Integer>>]
   def self.year_month_list(channel)
     where(channel: channel).
-      distinct.
-      order(:date).
-      pluck(Arel.sql('YEAR(date), MONTH(date)'))
+      group(:year, :month).
+      order(Arel.sql('EXTRACT(YEAR FROM date), EXTRACT(MONTH FROM date)')).
+      pluck(Arel.sql('EXTRACT(YEAR FROM date) AS year, ' \
+                     'EXTRACT(MONTH FROM date) AS month'))
   end
 end

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -16,8 +16,6 @@ default: &default
   collation: utf8mb4_general_ci
   pool: 5
   socket: /var/lib/mysql/mysql.sock
-  variables:
-    sql_mode: TRADITIONAL
 
 development:
   <<: *default

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -5,5 +5,3 @@ test:
   encoding: utf8mb4
   charset: utf8mb4
   collation: utf8mb4_general_ci
-  variables:
-    sql_mode: TRADITIONAL

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :user do
-    id { 1 }
     username { 'test_user' }
     email { '' }
     password { 'pa$$word' }


### PR DESCRIPTION
#129「Arel.sql を使わない形に書き換えた」で出た、`DISTINCT` の代わりに `GROUP BY` を使うようにする変更です。速度はほとんど変わらず、またMySQLのSQLモードに関わらず動作するという利点があります。