### PR TITLE
 irc-bot: アプリ名、バージョン、コミットIDを求める処理を共通化する

### DIFF
--- a/config/version.rb
+++ b/config/version.rb
@@ -5,11 +5,23 @@ module LogArchiver
     # Log Archiverのバージョン
     VERSION = '0.4.1'
 
+    # バージョンとコミットIDのキャッシュ用
+    # @return [String, nil]
+    @@version_and_commit_id = nil
+
     # バージョンとコミットIDを表す文字列を返す
     # @return [String]
     #
     # コミットID取得時にエラーが発生した場合は、返り値にコミットIDが含まれない。
+    #
+    # 一度実行したときに結果をキャッシュする。
+    # これは、再起動しない限り読み込まれたコードは更新されず、
+    # 実質的に初回実行時とバージョンが変わらないため。
+    # また、そのようにすることで、gitが何回も実行されるのを防ぐことができる。
     def self.version_and_commit_id
+      # 結果がキャッシュされていた場合は、それを返す
+      return @@version_and_commit_id if @@version_and_commit_id
+
       commit_id =
         begin
           Dir.chdir(root) do
@@ -19,7 +31,10 @@ module LogArchiver
           ''
         end
 
-      commit_id.empty? ? VERSION : "#{VERSION} (#{commit_id})"
+      @@version_and_commit_id =
+        commit_id.empty? ? VERSION : "#{VERSION} (#{commit_id})"
+
+      @@version_and_commit_id
     end
   end
 end

--- a/lib/ircs/irc_bot_version.rb
+++ b/lib/ircs/irc_bot_version.rb
@@ -1,0 +1,11 @@
+# vim: fileencoding=utf-8
+
+require_relative '../../config/version'
+
+module LogArchiver
+  module Ircs
+    # アプリケーション名、バージョン、コミットID
+    APP_NAME_VERSION_COMMIT_ID =
+      "IRC Log Archiver (IRC bot) #{Application.version_and_commit_id}"
+  end
+end

--- a/lib/ircs/plugins/ctcp.rb
+++ b/lib/ircs/plugins/ctcp.rb
@@ -1,6 +1,7 @@
 # vim: fileencoding=utf-8
 
 require_relative 'base'
+require_relative '../irc_bot_version'
 
 module LogArchiver
   module Plugin
@@ -30,7 +31,7 @@ module LogArchiver
       # @param [Cinch::Message] m
       # @return [void]
       def ctcp_version(m)
-        ctcp_reply(m, "log-archiver_ircbot #{Application.version_and_commit_id}")
+        ctcp_reply(m, Ircs::APP_NAME_VERSION_COMMIT_ID)
       end
 
       def ctcp_ping(m)

--- a/lib/ircs/plugins/version.rb
+++ b/lib/ircs/plugins/version.rb
@@ -1,6 +1,7 @@
 # vim: fileencoding=utf-8
 
 require_relative 'base'
+require_relative '../irc_bot_version'
 
 module LogArchiver
   module Plugin
@@ -13,14 +14,8 @@ module LogArchiver
 
       match(/version/, method: :version)
 
-      def initialize(*)
-        super
-
-        @version = "IRC Log Archiver #{Application.version_and_commit_id}"
-      end
-
       def version(m)
-        send_and_record(m, @version)
+        send_and_record(m, Ircs::APP_NAME_VERSION_COMMIT_ID)
       end
     end
   end

--- a/test/ircs/irc_bot_version_test.rb
+++ b/test/ircs/irc_bot_version_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+require_relative '../../lib/ircs/irc_bot_version.rb'
+
+class IrcBotVersionTest < ActiveSupport::TestCase
+  test '正しい形式でアプリケーション名、バージョン、コミットIDが得られる' do
+    assert_match(/\AIRC Log Archiver \(IRC bot\) \d+\.\d+\.\d+ \(\w+\)\z/,
+                 LogArchiver::Ircs::APP_NAME_VERSION_COMMIT_ID)
+  end
+end


### PR DESCRIPTION
IRCボットのVersion、Ctcpプラグインの両者でバージョン情報を返す処理が似ていたので、共通化してみました。