### PR TITLE
一般向けのチャンネル一覧ページから、正規 URL へのリンクを削除

### DIFF
--- a/app/views/channels/index.html.erb
+++ b/app/views/channels/index.html.erb
@@ -16,7 +16,6 @@
                 <th class="channel-name">チャンネル名</th>
                 <th class="channel-last-speech">最終発言日時</th>
                 <th class="channel-logging-enabled">ログ記録中</th>
-                <th class="canonical-site-url">正規 URL</th>
               </tr>
             </thead>
             <tbody>
@@ -25,7 +24,6 @@
                   <td class="channel-name"><%= link_to(channel.name_with_prefix, channel) %></td>
                   <td class="channel-last-speech"><%= last_speech_timestamp_link(channel) %></td>
                   <td class="channel-logging-enabled"><%= channel.logging_enabled? ? fa_icon('check') : '' %></td>
-                  <td class="canonical-site-url"><%= channel.canonical_url_template? ? link_to(channel.canonical_base_url, channel.canonical_base_url) : '' %></td>
                 </tr>
               <% end %>
             </tbody>


### PR DESCRIPTION
一般向けのチャンネル一覧ページ (/channels) では、正規 URL のリンクを削除した。
チャンネル詳細ページ (/channels/<ch name>) に表示されていることと、スマホで見たときに形が崩れることを避けたい。