### PR TITLE
sassc-railsを使う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'mysql2', '~> 0.5.2'
 gem 'activerecord-import'
 
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '>= 2.1'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,20 +245,15 @@ GEM
       rubocop (>= 0.70.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
+    sassc-rails (2.1.1)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sdoc (1.0.0)
       rdoc (>= 5.0)
     shellany (0.0.1)
@@ -342,7 +337,7 @@ DEPENDENCIES
   rinku!
   rubocop
   rubocop-rails
-  sass-rails (~> 5.0)
+  sassc-rails (>= 2.1)
   sdoc (~> 1.0.0)
   simple_calendar (~> 2.0)
   simple_enum


### PR DESCRIPTION
C++のライブラリによってSassのコンパイルを速く行うことができる、sassc-railsを使うようにします。従来のruby-sassは非推奨になり、それを利用しているrails-sassも非推奨となっているようです。

参考: http://sass.logdown.com/posts/7081811