### PR TITLE
IRCボット：シグナル受信で正常に終了しない問題を修正する

### DIFF
--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -30,7 +30,7 @@ module LogArchiver
 
       bot = new_bot(config, plugins, log_level)
 
-      @quit_message = config.irc_bot['QuitMessage']
+      @quit_message = config.irc_bot['QuitMessage'] || ''
       set_signal_handler(bot)
       bot.start
 

--- a/lib/ircs/irc_bot.rb
+++ b/lib/ircs/irc_bot.rb
@@ -30,7 +30,9 @@ module LogArchiver
 
       bot = new_bot(config, plugins, log_level)
 
-      @quit_message = config.irc_bot['QuitMessage'] || ''
+      # 後に @quit_message.empty? を実行するため、
+      # NoMethodError などの例外が発生しないよう文字列化しておく
+      @quit_message = config.irc_bot['QuitMessage'].to_s
       set_signal_handler(bot)
       bot.start
 


### PR DESCRIPTION
設定ファイルで `QuitMessage` が設定されていない場合、IRCボットをシグナル送信で終了できない問題がありました。

原因は次のとおりです。`@quit_message` は、設定ファイルで `QuitMessage` が設定されていない
場合 `nil` となります。そのとき、シグナルハンドラ内の `@quit_message.empty?` で
`NoMethodError` が発生します。この例外が発生すれば `bot.quit` が失敗するため、シグナルを送っても終了できません。

対策として、`QuitMessage` が設定されていない場合は、既定値として空文字列を設定するようにします。