### PR TITLE
不要な外部キー制約が存在すれば削除する 

### DIFF
--- a/db/migrate/20190625165200_drop_foreign_key_from_conversation_messages_to_irc_users_if_exists.rb
+++ b/db/migrate/20190625165200_drop_foreign_key_from_conversation_messages_to_irc_users_if_exists.rb
@@ -1,0 +1,14 @@
+class DropForeignKeyFromConversationMessagesToIrcUsersIfExists < ActiveRecord::Migration[5.2]
+  def up
+    unless foreign_key_exists?(:conversation_messages, :irc_users)
+      puts('conversation_messages -> irc_users の外部キー制約は存在しません')
+      return
+    end
+
+    remove_foreign_key(:conversation_messages, :irc_users)
+  end
+
+  def down
+    # 何もしない
+  end
+end


### PR DESCRIPTION
既存のマイグレーションの修正により消した外部キー制約 `conversation_messages -> irc_users` が残っていれば、新しいマイグレーションで削除するようにしてみました。もし手元にそのようなデータベースがあれば、試してみてください。