### PR TITLE
conversation_messagesのインデックスの修正

### DIFF
--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -71,7 +71,7 @@ class Channels::DaysController < ApplicationController
     timestamp_range = @date...(@date.next_day)
     messages = Message.
       includes(:channel, :irc_user).
-      where(channel: @channel, timestamp: timestamp_range).
+      where(timestamp: timestamp_range, channel: @channel).
       order(:timestamp, :id).
       to_a
     @conversation_messages = ConversationMessage.

--- a/db/migrate/20190901053654_add_indices_to_conversation_messages_20190901.rb
+++ b/db/migrate/20190901053654_add_indices_to_conversation_messages_20190901.rb
@@ -1,0 +1,9 @@
+class AddIndicesToConversationMessages20190901 < ActiveRecord::Migration[5.2]
+  def change
+    remove_index(:conversation_messages,
+                 column: [:timestamp, :channel_id, :type],
+                 name: 'index_cm_on_timestamp_and_channel_id_and_type')
+
+    add_index :conversation_messages, [:timestamp, :channel_id]
+  end
+end

--- a/db/migrate/20190901151835_cleanup_indices_201909.rb
+++ b/db/migrate/20190901151835_cleanup_indices_201909.rb
@@ -1,0 +1,14 @@
+class CleanupIndices201909 < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :messages, column: :channel_id
+    remove_index :messages, column: [:id, :channel_id, :timestamp]
+    remove_index :messages, column: [:id, :channel_id]
+    remove_index :messages, column: [:id, :timestamp]
+    remove_index :messages, column: :irc_user_id
+    remove_index :messages, column: :nick
+    remove_index :messages, column: :timestamp
+    remove_index :messages, column: :type
+
+    add_index :messages, [:timestamp, :channel_id]
+  end
+end

--- a/db/schema_dump.rb
+++ b/db/schema_dump.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_22_062447) do
+ActiveRecord::Schema.define(version: 2019_09_01_053654) do
 
   create_table "channel_last_speeches", id: :integer, options: "ENGINE=Mroonga DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "channel_id"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2019_06_22_062447) do
     t.index ["message", "nick"], name: "index_conversation_messages_on_message_and_nick", type: :fulltext
     t.index ["message"], name: "index_conversation_messages_on_message", type: :fulltext
     t.index ["nick"], name: "index_conversation_messages_on_nick", type: :fulltext
-    t.index ["timestamp", "channel_id", "type"], name: "index_cm_on_timestamp_and_channel_id_and_type"
+    t.index ["timestamp", "channel_id"], name: "index_conversation_messages_on_timestamp_and_channel_id"
     t.index ["type", "channel_id", "timestamp"], name: "index_cm_on_type_and_channel_id_and_timestamp"
   end
 

--- a/test/factories/nicks.rb
+++ b/test/factories/nicks.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     timestamp { '2016-04-01 12:35:01 +0900' }
     nick { 'rgrb' }
     message { 'rgrb2' }
+
+    factory :nick_foo_bar_20140320012354 do
+      timestamp { '2014-03-20 01:23:54 +0900' }
+      nick { 'foo' }
+      message { 'bar' }
+    end
   end
 end

--- a/test/integration/channels_days_show_test.rb
+++ b/test/integration/channels_days_show_test.rb
@@ -5,9 +5,10 @@ class ChannelsDaysShowTest < ActionDispatch::IntegrationTest
     create(:setting)
     create(:user)
 
-    @channel = create(:channel)
-
+    Message.delete_all
     ConversationMessage.delete_all
+
+    @channel = create(:channel)
 
     # NICK 1件
     create(:nick_foo_bar_20140320012354)
@@ -35,11 +36,12 @@ class ChannelsDaysShowTest < ActionDispatch::IntegrationTest
 
     date = Date.new(2014, 3, 20)
     @browse = ChannelBrowse::Day.new(channel: @channel,
-                                    date: date,
-                                    style: :normal)
+                                     date: date,
+                                     style: :normal)
   end
 
   teardown do
+    Message.delete_all
     ConversationMessage.delete_all
   end
 
@@ -51,9 +53,8 @@ class ChannelsDaysShowTest < ActionDispatch::IntegrationTest
                   '#irc_test 2014-03-20',
                   'チャンネル名と日付の見出しが存在する')
 
-    assert_select('tr.message', 5)
     assert_select('tr.message-type-nick', 1)
-    assert_select('tr.message-type-privmsg', 3)
     assert_select('tr.message-type-notice', 1)
+    assert_select('tr.message-type-privmsg', 3)
   end
 end

--- a/test/integration/channels_days_show_test.rb
+++ b/test/integration/channels_days_show_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class ChannelsDaysShowTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:setting)
+    create(:user)
+
+    @channel = create(:channel)
+
+    ConversationMessage.delete_all
+
+    # NICK 1件
+    create(:nick_foo_bar_20140320012354)
+
+    create_by_id = ->id { create(id) }
+
+    # NOTICE 1件
+    notice_factory_ids = [
+      :notice_toybox_20140320000000,
+      # 以下、別の日
+      :notice_toybox_20140321000000,
+      :notice
+    ]
+    notice_factory_ids.each(&create_by_id)
+
+    # PRIVMSG 3件
+    privmsg_factory_ids = [
+      :privmsg_rgrb_20140320012345,
+      :privmsg_role_20140320023456,
+      :privmsg_toybox_20140320210954,
+      # 以下、別の日
+      :privmsg
+    ]
+    privmsg_factory_ids.each(&create_by_id)
+
+    date = Date.new(2014, 3, 20)
+    @browse = ChannelBrowse::Day.new(channel: @channel,
+                                    date: date,
+                                    style: :normal)
+  end
+
+  teardown do
+    ConversationMessage.delete_all
+  end
+
+  test 'メッセージの一覧が正しく表示される' do
+    get(@browse.path)
+    assert_response(:success)
+
+    assert_select('h1',
+                  '#irc_test 2014-03-20',
+                  'チャンネル名と日付の見出しが存在する')
+
+    assert_select('tr.message', 5)
+    assert_select('tr.message-type-nick', 1)
+    assert_select('tr.message-type-privmsg', 3)
+    assert_select('tr.message-type-notice', 1)
+  end
+end


### PR DESCRIPTION
各日付のページで会話のメッセージ（PRIVMSG、NOTICE、TOPIC）が表示されない問題を修正しました。

* conversation_messages の `[:channel_id, :timestamp, :type]` のインデックスが邪魔をしていたようだったので、それを削除し、必要な `[:timestamp, :channel_id]`（SQL文の `WHERE` の順番に合わせることが重要）のインデックスを新しく作りました。
* messages のインデックスも整理しました。
* integration_testを追加し、画面のHTMLソースにも正しい件数のメッセージが現れていることを確認できるようにしました。