### PR TITLE
AppStatus: require_dependencyを追加する

### DIFF
--- a/lib/log_archiver/app_status.rb
+++ b/lib/log_archiver/app_status.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# development環境で正常にリロードするために必要
+require_dependency 'log_archiver/version'
+
 module LogArchiver
   # アプリケーションの状態を表すクラス
   class AppStatus


### PR DESCRIPTION
development環境で `VERSION` 周辺が変更された場合に正常にリロードするために、`require_dependency` が必要でした。追加前は `A copy of LogArchiver::VERSION has been removed from the module tree but is still active!` というエラーが出ました。