### PR TITLE
IRCボット: .log site descに反応しなかった問題を修正する

### DIFF
--- a/lib/ircs/plugins/user_interface.rb
+++ b/lib/ircs/plugins/user_interface.rb
@@ -99,7 +99,7 @@ module LogArchiver
       # サイト説明を返す
       # @param [Cinch::Message] m
       # @return [void]
-      def site_desc(m)
+      def site_description(m)
         header = ui_header('desc')
         send_and_record(m, header + Setting.first.text_on_homepage)
       end


### PR DESCRIPTION
IRCボットに対して `.log site desc`（サイトの説明文）を送っても反応しなかった問題を修正しました。

原因は、`match` で指定した名前のメソッド（`site_description`）が存在しなかったことでした（`site_desc` となっていた）。対応するメソッドの名前を指定された名前に合わせました。