### PR TITLE
JSON ダンプの IrcUser データ補完タスクの修正

### DIFF
--- a/lib/tasks/json/util.rake
+++ b/lib/tasks/json/util.rake
@@ -83,7 +83,7 @@ namespace :json do
       raise ArgumentError, '入力ファイルが指定されていません' unless filename
 
       begin
-        entries = JSON.parse(File.read(filename, encoding: 'UTF-8'))
+        JSON.parse(File.read(filename, encoding: 'UTF-8'))
       rescue => e
         $stderr.puts("#{filename} #{e}")
       end

--- a/lib/tasks/json/util.rake
+++ b/lib/tasks/json/util.rake
@@ -55,14 +55,18 @@ namespace :json do
         end
 
         # entry の書き換え
-        if (entry['user'].nil? || entry['user'] == DUMMY_USER) && (entry['host'].nil? || entry['host'] == DUMMY_HOST) && irc_users[channel].has_key?(nick)
+        user = entry['user']
+        host = entry['host']
+        user_is_nil_or_dummy = user.nil? || user == DUMMY_USER
+        host_is_nil_or_dummy = host.nil? || host == DUMMY_HOST
+        if user_is_nil_or_dummy && host_is_nil_or_dummy && irc_users[channel].has_key?(nick)
           entry['user'], entry['host'] = irc_users[channel][nick]
         end
 
         # キャッシュの管理
         case entry['type'].upcase
         when 'JOIN'
-          irc_users[channel][nick] = [entry['user'], entry['host']]
+          irc_users[channel][nick] = [user, host]
         when 'PART', 'QUIT'
           irc_users[channel].delete(nick)
         when 'NICK'

--- a/lib/tasks/json/util.rake
+++ b/lib/tasks/json/util.rake
@@ -37,6 +37,7 @@ namespace :json do
     task :complement_user_host, [:filename] => :environment do |_, args|
       entries = read_json(args[:filename])
 
+      # キャッシュデータの構造
       # {
       #   'channel'.downcase => {
       #     'nick'.downcase => ['user', 'host']


### PR DESCRIPTION
fix: #163 

各チャンネルについてキャッシュを作成するように変更しました。
それにより、連続する NICK/PART/QUIT メッセージの IrcUser データを補完できるようになりました。
また、チャンネル別にキャッシュを作成するため、PART メッセージ由来のバグも解決しました。

ToDo:
取得されているログが連続していない場合、キャッシュが再作成されないため間違ったデータが補完される可能性があります。
現在の実装では、予め与えるデータを分割し、連続しているログだけを一度に与える必要があります。
ログに、ログ取得ボット自身の PART/QUIT ログが残っていた場合には、予めログ取得ボットの NICK をタスクに与えておくことで、キャッシュの自動破棄が出来るかもしれません。しかしログ取得ボットの NICK も正確には分かりませんので、機能を追加してもあまり意味がないのではないかと考えます。