### PR TITLE
メッセージの表記のまま、キーワード部だけリンクに変える

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,4 +12,15 @@ class ApplicationController < ActionController::Base
     flash[:warning] = t('views.flash.login_first')
     redirect_to(login_path)
   end
+
+  # PRIVMSG-キーワードの関連をConversationMessageの集合から抽出する
+  # @param [Array<ConversationMessage>] messages ConversationMessageの配列
+  # @return [Array<PrivmsgKeywordRelationship>]
+  def privmsg_keyword_relationships_from(messages)
+    privmsgs = messages.to_a.select { |m| m.kind_of?(Privmsg) }
+    PrivmsgKeywordRelationship
+      .includes(:keyword)
+      .from_privmsgs(privmsgs)
+      .to_a
+  end
 end

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -80,11 +80,8 @@ class Channels::DaysController < ApplicationController
       order(:timestamp, :id).
       to_a
 
-    privmsgs = @conversation_messages.select { |m| m.kind_of?(Privmsg) }
-    @privmsg_keyword_relationships = PrivmsgKeywordRelationship
-      .from_privmsgs(privmsgs)
-      .to_a
-
+    @privmsg_keyword_relationships =
+      privmsg_keyword_relationships_from(@conversation_messages)
     @privmsg_keyword_relationships_for_header = @privmsg_keyword_relationships
       .uniq(&:keyword_id)
 

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -33,10 +33,8 @@ class ChannelsController < ApplicationController
       limit(3).
       reverse
 
-    privmsgs = @latest_speeches.to_a.select { |m| m.kind_of?(Privmsg) }
-    @privmsg_keyword_relationships = PrivmsgKeywordRelationship
-      .from_privmsgs(privmsgs)
-      .to_a
+    @privmsg_keyword_relationships =
+      privmsg_keyword_relationships_from(@latest_speeches)
 
     @years = MessageDate.
       where(channel: @channel).

--- a/app/controllers/messages/searches_controller.rb
+++ b/app/controllers/messages/searches_controller.rb
@@ -39,13 +39,9 @@ class Messages::SearchesController < ApplicationController
 
     if @message_search.valid?
       @result = @message_search.result
-
       @messages = @result.messages
-
-      privmsgs = @messages.select { |m| m.kind_of?(Privmsg) }
-      @privmsg_keyword_relationships = PrivmsgKeywordRelationship
-        .from_privmsgs(privmsgs)
-        .to_a
+      @privmsg_keyword_relationships =
+        privmsg_keyword_relationships_from(@messages)
 
       set_prev_link!(path_to_prev_page(@messages))
       set_next_link!(path_to_next_page(@messages))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,4 +75,22 @@ module ApplicationHelper
   def nav_tab_class(cond)
     cond ? 'active' : ''
   end
+
+  # PRIVMSGのキーワード部分にリンクを設定する
+  # @param [Privmsg] privmsg キーワードコマンドのPRIVMSG
+  # @param [Keyword] keyword 対応するキーワード
+  # @return [String]
+  def linkify_keyword(privmsg, keyword)
+    m = privmsg.message.match(/([ 　]+)/)
+    return sanitize(privmsg.message) unless m
+
+    command = m.pre_match
+    separator = m[1]
+    keyword_title = m.post_match
+
+    pre_keyword = sanitize("#{command}#{separator}")
+    link_to_keyword = link_to(sanitize(keyword_title), keyword_path(keyword))
+
+    raw("#{pre_keyword}#{link_to_keyword}")
+  end
 end

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -1,7 +1,7 @@
 <% anchor = m.fragment_id %>
 <% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date, style: style) %>
-<tr class="message message-type-<%= m.type.downcase %>">
-  <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor), id: anchor) %></td>
+<tr id="<%= anchor %>" class="message message-type-<%= m.type.downcase %>">
+  <td class="message-time"><%= link_to(m.timestamp.strftime('%T'), browse_day.path(anchor: anchor)) %></td>
   <% if show_channel %>
     <td class="message-channel"><%= link_to(m.channel.name_with_prefix, m.channel) %></td>
   <% end %>

--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -35,8 +35,7 @@
       <dl class="message">
         <dt><b class="nickname message-privmsg"><%= m.nick %></b></dt>
         <% if keyword = privmsg_id_keyword_map[m.id] %>
-          <% command_part = sanitize(m.message.sub(/([ 　]+).+/, '\1')) %>
-          <dd><%= command_part %><%= link_to(sanitize(keyword.display_title), keyword) %></dd>
+          <dd><%= linkify_keyword(m, keyword) %></dd>
         <% else %>
           <dd><%= raw(linkify(m.message)) %></dd>
         <% end %>

--- a/app/views/shared/_message_with_datetime.html.erb
+++ b/app/views/shared/_message_with_datetime.html.erb
@@ -1,7 +1,7 @@
 <% anchor = m.fragment_id %>
 <% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
 <tr class="message message-type-<%= m.type.downcase %>">
-  <td class="message-datetime"><%= link_to(m.timestamp.strftime('%F %T'), browse_day.path(anchor: anchor), id: anchor) %></td>
+  <td class="message-datetime"><%= link_to(m.timestamp.strftime('%F %T'), browse_day.path(anchor: anchor)) %></td>
   <% if show_channel %>
     <td class="message-channel"><%= link_to(m.channel.name_with_prefix, m.channel) %></td>
   <% end %>

--- a/app/views/shared/_message_with_datetime.html.erb
+++ b/app/views/shared/_message_with_datetime.html.erb
@@ -35,8 +35,7 @@
       <dl class="message">
         <dt><b class="nickname message-privmsg"><%= m.nick %></b></dt>
         <% if keyword = privmsg_id_keyword_map[m.id] %>
-          <% command_part = sanitize(m.message.sub(/([ 　]+).+/, '\1')) %>
-          <dd><%= command_part %><%= link_to(sanitize(keyword.display_title), keyword) %></dd>
+          <dd><%= linkify_keyword(m, keyword) %></dd>
         <% else %>
           <dd><%= raw(linkify(m.message)) %></dd>
         <% end %>

--- a/test/factories/channel_last_speeches.rb
+++ b/test/factories/channel_last_speeches.rb
@@ -3,7 +3,13 @@ FactoryBot.define do
     channel
     conversation_message
 
-    initialize_with { ChannelLastSpeech.find_or_create_by(channel: channel) }
+    initialize_with {
+      ChannelLastSpeech.find_or_initialize_by(
+        channel: channel
+      ) do |new_channel_last_speech|
+        new_channel_last_speech.attributes = attributes
+      end
+    }
 
     factory :channel_100_last_speech do
       association :channel, factory: :channel_100

--- a/test/factories/channels.rb
+++ b/test/factories/channels.rb
@@ -4,7 +4,11 @@ FactoryBot.define do
     identifier { 'irc_test' }
     logging_enabled { true }
 
-    initialize_with { Channel.find_or_create_by(identifier: identifier) }
+    initialize_with {
+      Channel.find_or_initialize_by(identifier: identifier) do |new_channel|
+        new_channel.attributes = attributes
+      end
+    }
 
     factory :channel_with_camel_case_name do
       name { 'CamelCaseChannel' }

--- a/test/factories/irc_users.rb
+++ b/test/factories/irc_users.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     user { 'rgrb_bot' }
     host { 'irc.cre.jp' }
 
-    initialize_with { IrcUser.find_or_create_by(user: user) }
+    initialize_with {
+      IrcUser.find_or_initialize_by(user: user, host: host)
+    }
 
     factory :irc_user_role do
       user { 'Role' }

--- a/test/factories/keywords.rb
+++ b/test/factories/keywords.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
   factory :keyword do
-    title { 'キーワードa_1' }
-    display_title { 'キーワードA 1' }
+    title { 'sword_world_2.0' }
+    display_title { 'Sword World 2.0' }
 
-    initialize_with { Keyword.find_or_create_by(title: title) }
+    initialize_with {
+      Keyword.find_or_initialize_by(title: title) do |new_keyword|
+        new_keyword.attributes = attributes
+      end
+    }
   end
 end

--- a/test/factories/message_dates.rb
+++ b/test/factories/message_dates.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     date { '2016-08-16' }
 
     initialize_with {
-      MessageDate.find_or_create_by(channel: channel, date: date)
+      MessageDate.find_or_initialize_by(channel: channel, date: date)
     }
 
     factory :message_date_20150123 do

--- a/test/factories/privmsgs.rb
+++ b/test/factories/privmsgs.rb
@@ -24,5 +24,25 @@ FactoryBot.define do
       nick { 'Toybox' }
       message { 'Toybox (irc.cre.jp)' }
     end
+
+    factory :privmsg_keyword_sw_k do
+      timestamp { '2019-10-20 01:23:45 +0900' }
+      message { '.k Sword World 2.0' }
+    end
+
+    factory :privmsg_keyword_sw_a do
+      timestamp { '2019-10-20 01:23:45 +0900' }
+      message { '.a Sword World 2.0' }
+    end
+
+    factory :privmsg_keyword_sw_capital do
+      timestamp { '2019-10-20 01:23:55 +0900' }
+      message { '.k SWORD WORLD 2.0' }
+    end
+
+    factory :privmsg_keyword_sw_zenkaku do
+      timestamp { '2019-10-20 01:24:05 +0900' }
+      message { '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０' }
+    end
   end
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :setting do
+    id { 1 }
     site_title { 'IRC ログアーカイブ' }
     text_on_homepage { 'このサイトでは IRC ログを記録しています。' }
+
+    initialize_with {
+      Setting.find_or_initialize_by(id: id) do |new_setting|
+        new_setting.attributes = attributes
+      end
+    }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     password { 'pa$$word' }
     password_confirmation { 'pa$$word' }
 
-    initialize_with { User.find_or_create_by(username: username) }
+    initialize_with {
+      User.find_or_initialize_by(username: username) do |new_user|
+        new_user.attributes = attributes
+      end
+    }
   end
 end

--- a/test/integration/channels_days_show_linking_to_keyword_test.rb
+++ b/test/integration/channels_days_show_linking_to_keyword_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:setting)
+    create(:user)
+
+    PrivmsgKeywordRelationship.delete_all
+    Message.delete_all
+    ConversationMessage.delete_all
+    Keyword.delete_all
+
+    @keyword = create(:keyword)
+
+    # メッセージの準備
+
+    privmsg_factory_ids = [
+      :privmsg_keyword_sw_k,
+      :privmsg_keyword_sw_a,
+      :privmsg_keyword_sw_capital,
+      :privmsg_keyword_sw_zenkaku
+    ]
+    @privmsgs = privmsg_factory_ids.map { |id| create(id) }
+  end
+
+  teardown do
+    PrivmsgKeywordRelationship.delete_all
+    Message.delete_all
+    ConversationMessage.delete_all
+    Keyword.delete_all
+  end
+
+  test 'キーワードのリンク先および表記が正しい' do
+    # メッセージとキーワードを関連付ける
+    @privmsgs.each do |privmsg|
+      LogArchiver::ExtractKeyword.run(privmsg)
+    end
+
+    # すべてのメッセージが同じキーワードと関連付けられていることを確認する
+    @privmsgs.each do |privmsg|
+      assert_equal(@keyword.id, privmsg.keyword.id,
+                   %Q|"#{privmsg.message}: 対応するキーワードが正しい"|)
+    end
+
+    # 1日ごとのログページを閲覧する
+
+    date = @privmsgs[0].timestamp.to_date
+    channel = @privmsgs[0].channel
+    @browse = ChannelBrowse::Day.new(channel: channel,
+                                     date: date,
+                                     style: :normal)
+
+    get(@browse.path)
+
+    # キーワード部分のリンク先が正しいことを確認する
+    @privmsgs.each do |privmsg|
+      assert_select("##{privmsg.fragment_id} .message dd a", 1) do |links|
+        assert_equal(keyword_path(privmsg.keyword), links[0]['href'],
+                     %Q|"#{privmsg.message.inspect}: キーワード部分のリンク先が正しい"|)
+      end
+    end
+
+    # メッセージの表記が正しいことを確認する
+    @privmsgs.each do |privmsg|
+      assert_select("##{privmsg.fragment_id} .message dd", 1) do |elements|
+        assert_equal(privmsg.message, elements[0].content,
+                     %Q|"#{privmsg.message.inspect}: メッセージの表記が正しい"|)
+      end
+    end
+  end
+end


### PR DESCRIPTION
キーワードコマンドのPRIVMSGについて、リンクが設定されてもメッセージの内容が極力変わらないように改善してみました。1日ごとのログページについてテストを追加して、このように表示されることを確認しました。