### PR TITLE
1日ごとのログのヘッダ：キーワード入りメッセージへのリンク（時刻表記）を追加する

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -162,6 +162,7 @@ table.day-summary {
   th {
     padding-right: 1em;
     text-align: right;
+    vertical-align: top;
     white-space: nowrap;
   }
 }
@@ -316,10 +317,6 @@ textarea.text-on-homepage {
 
 .keyword-num-of-privmsgs {
   text-align: right;
-}
-
-.channel-day-keyword-link {
-  margin-right: 0.5em;
 }
 
 footer {

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -167,6 +167,20 @@ table.day-summary {
   }
 }
 
+a.keyword-list-time {
+  margin-left: 0.25em;
+  margin-right: 0.25em;
+  font-size: $font-size-small;
+
+  &:link, &:visited {
+    color: $gray;
+  }
+
+  &:hover {
+    color: $link-hover-color;
+  }
+}
+
 .message-visibility {
   th {
     vertical-align: top;

--- a/app/controllers/channels/days_controller.rb
+++ b/app/controllers/channels/days_controller.rb
@@ -82,8 +82,10 @@ class Channels::DaysController < ApplicationController
 
     @privmsg_keyword_relationships =
       privmsg_keyword_relationships_from(@conversation_messages)
-    @privmsg_keyword_relationships_for_header = @privmsg_keyword_relationships
-      .uniq(&:keyword_id)
+    @keywords_privmsgs_for_header = @privmsg_keyword_relationships
+      .sort_by { |r| r.privmsg.timestamp }
+      .group_by(&:keyword)
+      .map { |keyword, relations| [keyword, relations.map(&:privmsg)] }
 
     @browse_day_normal = ChannelBrowse::Day.new(
       channel: @channel, date: @date, style: :normal

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -35,8 +35,10 @@
                         <ul class="list-unstyled">
                           <% @keywords_privmsgs_for_header.each do |keyword, privmsgs| %>
                             <li>
-                              <% privmsg_links = privmsgs.map { |m| link_to(m.timestamp.strftime('%T'), "##{m.fragment_id}") } %>
-                              <%= link_to(sanitize(keyword.display_title), keyword, class: 'channel-day-keyword-link') %>（<%= raw(privmsg_links.join('、')) %>）
+                              <%= link_to(sanitize(keyword.display_title), keyword, class: 'channel-day-keyword-link') %>
+                              <% privmsgs.each do |m| %>
+                                <%= link_to(m.timestamp.strftime('%T'), "##{m.fragment_id}", class: 'keyword-list-time') %>
+                              <% end %>
                             </li>
                           <% end %>
                         </ul>

--- a/app/views/channels/days/show.html.erb
+++ b/app/views/channels/days/show.html.erb
@@ -29,12 +29,17 @@
                     <td><%= @conversation_messages.length %></td>
                   </tr>
                   <% unless @privmsg_keyword_relationships.empty? %>
-                    <tr>
+                    <tr id="keyword-list">
                       <th scope="row">キーワード</th>
                       <td>
-                        <% @privmsg_keyword_relationships_for_header.each do |r| %>
-                          <%= link_to(sanitize(r.keyword.display_title), r.keyword, class: 'channel-day-keyword-link') %>
-                        <% end %>
+                        <ul class="list-unstyled">
+                          <% @keywords_privmsgs_for_header.each do |keyword, privmsgs| %>
+                            <li>
+                              <% privmsg_links = privmsgs.map { |m| link_to(m.timestamp.strftime('%T'), "##{m.fragment_id}") } %>
+                              <%= link_to(sanitize(keyword.display_title), keyword, class: 'channel-day-keyword-link') %>（<%= raw(privmsg_links.join('、')) %>）
+                            </li>
+                          <% end %>
+                        </ul>
                       </td>
                     </tr>
                   <% end %>

--- a/test/factories/privmsgs.rb
+++ b/test/factories/privmsgs.rb
@@ -25,21 +25,25 @@ FactoryBot.define do
       message { 'Toybox (irc.cre.jp)' }
     end
 
+    # fragment_id: #c190465ea
     factory :privmsg_keyword_sw_k do
       timestamp { '2019-10-20 01:23:45 +0900' }
       message { '.k Sword World 2.0' }
     end
 
+    # fragment_id: #c4f6f174d
     factory :privmsg_keyword_sw_a do
       timestamp { '2019-10-20 01:23:55 +0900' }
       message { '.a Sword World 2.0' }
     end
 
+    # fragment_id: #c110eb57c
     factory :privmsg_keyword_sw_capital do
       timestamp { '2019-10-20 01:24:05 +0900' }
       message { '.k SWORD WORLD 2.0' }
     end
 
+    # fragment_id: #c53c2aad9
     factory :privmsg_keyword_sw_zenkaku do
       timestamp { '2019-10-20 01:24:15 +0900' }
       message { '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０' }

--- a/test/factories/privmsgs.rb
+++ b/test/factories/privmsgs.rb
@@ -31,17 +31,17 @@ FactoryBot.define do
     end
 
     factory :privmsg_keyword_sw_a do
-      timestamp { '2019-10-20 01:23:45 +0900' }
+      timestamp { '2019-10-20 01:23:55 +0900' }
       message { '.a Sword World 2.0' }
     end
 
     factory :privmsg_keyword_sw_capital do
-      timestamp { '2019-10-20 01:23:55 +0900' }
+      timestamp { '2019-10-20 01:24:05 +0900' }
       message { '.k SWORD WORLD 2.0' }
     end
 
     factory :privmsg_keyword_sw_zenkaku do
-      timestamp { '2019-10-20 01:24:05 +0900' }
+      timestamp { '2019-10-20 01:24:15 +0900' }
       message { '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０' }
     end
   end

--- a/test/integration/channels_days_show_linking_to_keyword_test.rb
+++ b/test/integration/channels_days_show_linking_to_keyword_test.rb
@@ -41,7 +41,7 @@ class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
     # すべてのメッセージが同じキーワードと関連付けられていることを確認する
     @privmsgs.each do |privmsg|
       assert_equal(@keyword.id, privmsg.keyword.id,
-                   %Q|"#{privmsg.message}: 対応するキーワードが正しい"|)
+                   "#{privmsg.message.inspect}: 対応するキーワードが正しい")
     end
 
     # 1日ごとのログページを閲覧する
@@ -58,7 +58,7 @@ class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
     @privmsgs.each do |privmsg|
       assert_select("##{privmsg.fragment_id} .message dd a", 1) do |links|
         assert_equal(keyword_path(privmsg.keyword), links[0]['href'],
-                     %Q|"#{privmsg.message.inspect}: キーワード部分のリンク先が正しい"|)
+                     "#{privmsg.message.inspect}: キーワード部分のリンク先が正しい")
       end
     end
 
@@ -66,7 +66,30 @@ class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
     @privmsgs.each do |privmsg|
       assert_select("##{privmsg.fragment_id} .message dd", 1) do |elements|
         assert_equal(privmsg.message, elements[0].content,
-                     %Q|"#{privmsg.message.inspect}: メッセージの表記が正しい"|)
+                     "#{privmsg.message.inspect}: メッセージの表記が正しい")
+      end
+    end
+
+    # ヘッダのキーワード一覧の表示が正しいことを確認する
+    assert_select('#keyword-list td') do
+      assert_select(
+        'a',
+        { text: @keyword.display_title, count: 1 },
+        'ヘッダ: キーワードへのリンクが存在する'
+      ) do |links|
+        assert_equal(keyword_path(@keyword), links[0]['href'],
+                     'ヘッダ: キーワードのリンク先が正しい')
+      end
+
+      @privmsgs.each do |privmsg|
+        assert_select(
+          'a',
+          { text: privmsg.timestamp.strftime('%T'), count: 1 },
+          "ヘッダ: #{privmsg.message.inspect}: リンク（時刻表記）が存在する"
+        ) do |links|
+          assert_equal("##{privmsg.fragment_id}", links[0]['href'],
+                       "ヘッダ: #{privmsg.message.inspect}: リンク先が正しい")
+        end
       end
     end
   end

--- a/test/integration/channels_days_show_linking_to_keyword_test.rb
+++ b/test/integration/channels_days_show_linking_to_keyword_test.rb
@@ -6,6 +6,7 @@ class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
   setup do
     create(:setting)
     create(:user)
+    @channel = create(:channel)
 
     PrivmsgKeywordRelationship.delete_all
     Message.delete_all
@@ -46,51 +47,103 @@ class ChannelsDaysShowLinkingToKeywordTest < ActionDispatch::IntegrationTest
 
     # 1日ごとのログページを閲覧する
 
-    date = @privmsgs[0].timestamp.to_date
-    channel = @privmsgs[0].channel
-    @browse = ChannelBrowse::Day.new(channel: channel,
-                                     date: date,
+    @browse = ChannelBrowse::Day.new(channel: @channel,
+                                     date: Date.new(2019, 10, 20),
                                      style: :normal)
 
     get(@browse.path)
 
     # キーワード部分のリンク先が正しいことを確認する
-    @privmsgs.each do |privmsg|
-      assert_select("##{privmsg.fragment_id} .message dd a", 1) do |links|
-        assert_equal(keyword_path(privmsg.keyword), links[0]['href'],
-                     "#{privmsg.message.inspect}: キーワード部分のリンク先が正しい")
-      end
+
+    expected_keyword_path = '/keywords/sword_world_2_0'
+
+    assert_select('#c190465ea .message dd a', 1) do |links|
+      assert_equal(expected_keyword_path, links[0]['href'],
+                   '".k Sword World 2.0": キーワード部分のリンク先が正しい')
+    end
+
+    assert_select('#c4f6f174d .message dd a', 1) do |links|
+      assert_equal(expected_keyword_path, links[0]['href'],
+                   '".a Sword World 2.0": キーワード部分のリンク先が正しい')
+    end
+
+    assert_select('#c110eb57c .message dd a', 1) do |links|
+      assert_equal(expected_keyword_path, links[0]['href'],
+                   '".k SWORD WORLD 2.0": キーワード部分のリンク先が正しい')
+    end
+
+    assert_select('#c53c2aad9 .message dd a', 1) do |links|
+      assert_equal(expected_keyword_path, links[0]['href'],
+                   '".k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０": キーワード部分のリンク先が正しい')
     end
 
     # メッセージの表記が正しいことを確認する
-    @privmsgs.each do |privmsg|
-      assert_select("##{privmsg.fragment_id} .message dd", 1) do |elements|
-        assert_equal(privmsg.message, elements[0].content,
-                     "#{privmsg.message.inspect}: メッセージの表記が正しい")
-      end
-    end
+    assert_select('#c190465ea .message dd',
+                  { text: '.k Sword World 2.0', count: 1 },
+                  '".k Sword World 2.0": キーワード部分のリンク先が正しい')
+
+    assert_select('#c4f6f174d .message dd',
+                  { text: '.a Sword World 2.0', count: 1 },
+                  '".a Sword World 2.0": キーワード部分のリンク先が正しい')
+
+    assert_select('#c110eb57c .message dd',
+                  { text: '.k SWORD WORLD 2.0', count: 1 },
+                  '".k SWORD WORLD 2.0": キーワード部分のリンク先が正しい')
+
+    assert_select('#c53c2aad9 .message dd',
+                  { text: '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０', count: 1 },
+                  '".k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０": キーワード部分のリンク先が正しい')
 
     # ヘッダのキーワード一覧の表示が正しいことを確認する
-    assert_select('#keyword-list td') do
+    assert_select('#keyword-list td') do |td|
       assert_select(
         'a',
-        { text: @keyword.display_title, count: 1 },
+        { text: 'Sword World 2.0', count: 1 },
         'ヘッダ: キーワードへのリンクが存在する'
       ) do |links|
-        assert_equal(keyword_path(@keyword), links[0]['href'],
+        assert_equal(expected_keyword_path, links[0]['href'],
                      'ヘッダ: キーワードのリンク先が正しい')
       end
 
-      @privmsgs.each do |privmsg|
-        assert_select(
-          'a',
-          { text: privmsg.timestamp.strftime('%T'), count: 1 },
-          "ヘッダ: #{privmsg.message.inspect}: リンク（時刻表記）が存在する"
-        ) do |links|
-          assert_equal("##{privmsg.fragment_id}", links[0]['href'],
-                       "ヘッダ: #{privmsg.message.inspect}: リンク先が正しい")
-        end
+      assert_select(
+        'a',
+        { text: '01:23:45', count: 1 },
+        'ヘッダ: ".k Sword World 2.0": リンク（時刻表記）が存在する'
+      ) do |links|
+        assert_equal('#c190465ea', links[0]['href'],
+                     'ヘッダ: ".k Sword World 2.0": リンク先が正しい')
       end
+
+      assert_select(
+        'a',
+        { text: '01:23:55', count: 1 },
+        'ヘッダ: ".a Sword World 2.0": リンク（時刻表記）が存在する'
+      ) do |links|
+        assert_equal('#c4f6f174d', links[0]['href'],
+                     'ヘッダ: ".a Sword World 2.0": リンク先が正しい')
+      end
+
+      assert_select(
+        'a',
+        { text: '01:24:05', count: 1 },
+        'ヘッダ: ".k SWORD WORLD 2.0": リンク（時刻表記）が存在する'
+      ) do |links|
+        assert_equal('#c110eb57c', links[0]['href'],
+                     'ヘッダ: ".k SWORD WORLD 2.0": リンク先が正しい')
+      end
+
+      assert_select(
+        'a',
+        { text: '01:24:15', count: 1 },
+        'ヘッダ: ".k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０": リンク（時刻表記）が存在する'
+      ) do |links|
+        assert_equal('#c53c2aad9', links[0]['href'],
+                     'ヘッダ: ".k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０": リンク先が正しい')
+      end
+
+      assert_select('li',
+                    /01:23:45\s+01:23:55\s+01:24:05\s+01:24:15/,
+                    '時刻の順序が正しい')
     end
   end
 end


### PR DESCRIPTION
https://github.com/cre-ne-jp/log-archiver/pull/13#issuecomment-542952039 で提案されていた、1日ごとのログのヘッダにキーワード入り発言へのリンク（発言時刻表記）を追加する変更です。

# 画面例

<img width="719" alt="log_archiver-channels_days_show-header" src="https://user-images.githubusercontent.com/2551173/67500827-3c748880-f6be-11e9-9877-4aea1d646781.png">
