### PR TITLE
ハッシュ値算出元文字列に、チャンネル識別子を追加した

### DIFF
--- a/app/models/concerns/message_digest.rb
+++ b/app/models/concerns/message_digest.rb
@@ -19,7 +19,7 @@ module MessageDigest
   # メッセージの内容からハッシュ値の文字列表現を生成する
   # @return [String]
   def generate_digest
-    original_string = "#{timestamp.to_i} #{type} #{nick} #{message}"
+    original_string = "#{timestamp.to_i} #{type} #{channel.identifier} #{nick} #{message}"
     hash_integer = CFNV.fnv1a32(original_string)
 
     sprintf(DIGEST_FORMAT, hash_integer)


### PR DESCRIPTION
Join や Quit メッセージのハッシュ値が重なってしまうため