### PR TITLE
Sprockets: manifest.jsを修正する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ gem 'xmlrpc'
 gem 'rails', '~> 6.0'
 # Use mysql as the database for Active Record
 gem 'mysql2', '~> 0.5'
-# Sprockets 4.x では、SCSS コンパイル時にエラーが発生する
-gem 'sprockets', '~> 3'
 
 # バルクアップデートに使う
 gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,7 @@ GEM
       oauth (~> 0.4, >= 0.4.4)
       oauth2 (~> 1.0, >= 0.8.0)
     spring (2.1.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -347,7 +347,6 @@ DEPENDENCIES
   simplecov
   sorcery
   spring
-  sprockets (~> 3)
   sysexits
   uglifier (>= 1.3)
   unicorn

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
 //= link application.css
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css


### PR DESCRIPTION
Sprockets 4でSCSSコンパイル時にエラーが発生していたことについて、manifest.jsを修正すると直りました。application.scssが他のSCSSファイルをすべてインポートするため、`link_directory ../stylesheets .css` が不要でした。この修正により、Sprockets 4が使えるようになりました。