### PR TITLE
Unicorn プロセスをリクエスト数・メモリ使用量によって再起動する設定を追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'meta-tags'
 
 # Use Unicorn as the app server
 gem 'unicorn'
+gem 'unicorn-worker-killer'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
     formatador (0.2.5)
     friendly_id (5.3.0)
       activerecord (>= 4.0.0)
+    get_process_mem (0.2.5)
+      ffi (~> 1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.16.1)
@@ -296,6 +298,9 @@ GEM
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     web-console (4.0.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -353,6 +358,7 @@ DEPENDENCIES
   sysexits
   uglifier (>= 1.3)
   unicorn
+  unicorn-worker-killer
   web-console (~> 4.0)
   xmlrpc
 

--- a/config.ru
+++ b/config.ru
@@ -2,3 +2,6 @@
 
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application
+
+use Unicorn::WorkerKiller::MaxRequests, 1024, 2048, true
+use Unicorn::WorkerKiller::Oom, (192*(1024**2)), (256*(1024**2))


### PR DESCRIPTION
Unicorn がメモリを使いすぎる問題を対策しました。
PHP-FPM の初期設定のように、処理リクエスト数やメモリの使用量によって自動的に Unicorn プロセスを再起動してメモリの使用量を減らすようにしました。