### PR TITLE
キーワード未登録時、キーワード一覧画面でその旨を表示する

### DIFF
--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -10,26 +10,30 @@
             <h1>キーワード</h1>
           </div>
 
-          <p><%= page_entries_info(@keyword_privmsg_counts) %></p>
+          <% if @keyword_privmsg_counts.empty? %>
+            <div class="alert alert-info">キーワードが登録されていません。</div>
+          <% else %>
+            <p><%= page_entries_info(@keyword_privmsg_counts) %></p>
 
-          <table class="table table-striped keyword-list">
-            <thead>
-              <tr>
-                <th class="keyword-keyword">キーワード</th>
-                <th class="keyword-num-of-privmsgs">発言数</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @keyword_privmsg_counts.each do |keyword| %>
+            <table class="table table-striped keyword-list">
+              <thead>
                 <tr>
-                  <td class="keyword-keyword"><%= link_to(h(keyword.display_title), keyword) %></td>
-                  <td class="keyword-num-of-privmsgs"><%= keyword.privmsg_count %></td>
+                  <th class="keyword-keyword">キーワード</th>
+                  <th class="keyword-num-of-privmsgs">発言数</th>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                <% @keyword_privmsg_counts.each do |keyword| %>
+                  <tr>
+                    <td class="keyword-keyword"><%= link_to(h(keyword.display_title), keyword) %></td>
+                    <td class="keyword-num-of-privmsgs"><%= keyword.privmsg_count %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
 
-          <%= paginate(@keyword_privmsg_counts, outer_window: 2) %>
+            <%= paginate(@keyword_privmsg_counts, outer_window: 2) %>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
キーワード未登録時、キーワード一覧画面（`/keywords`）で、以下のメッセージを表示するようにしてみました。
![log-archiver-no_keyword](https://user-images.githubusercontent.com/2551173/76680828-948d3680-662f-11ea-9a19-818c3e1fe189.png)
