### PR TITLE
フラグメント識別子再設定：Redisに接続できない場合でも管理画面を表示できるようにする

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,10 @@ jobs:
         image: groonga/mroonga:latest
         ports:
           - 33060:3306
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/app/controllers/admin/status_controller.rb
+++ b/app/controllers/admin/status_controller.rb
@@ -19,6 +19,12 @@ class Admin::StatusController < ApplicationController
       @exception_on_fetching_irc_bot_status = e
     end
 
-    @sidekiq_statuses = Sidekiq::Stats.new
+    @sidekiq_stats = nil
+    @exception_on_fetching_sidekiq_stats = nil
+    begin
+      @sidekiq_stats = Sidekiq::Stats.new
+    rescue => e
+      @exception_on_fetching_sidekiq_stats = e
+    end
   end
 end

--- a/app/views/admin/status/show.html.erb
+++ b/app/views/admin/status/show.html.erb
@@ -36,7 +36,8 @@
             <h2>IRCボットの状態</h2>
             <% if @exception_on_fetching_irc_bot_status %>
               <div class="alert alert-danger">
-                <%= fa_icon('exclamation-triangle') %> IRCボットの状態を取得できませんでした: <%= @exception_on_fetching_irc_bot_status.message %>
+                <p><%= fa_icon('exclamation-triangle') %> IRCボットの状態を取得できませんでした: <%= @exception_on_fetching_irc_bot_status.message %></p>
+                <p>IRCボットが起動されているか確認してください。</p>
               </div>
             <% else %>
               <table class="table table-striped irc-bot-status-list">
@@ -58,45 +59,52 @@
             <% end %>
           </section>
 
-          <section class="sidekiq-status">
-            <h2>バックグラウンドジョブの状態</h2>
-            <p><%= link_to('詳細を見る(Sidekiq Dashboard)', admin_sidekiq_web_path) %></p>
-            <table class="table table-striped sidekiq-status-list">
-              <tbody>
-                <tr>
-                  <th class="sidekiq-status-version">バージョン</th>
-                  <td id="sidekiq-version" class="sidekiq-status-version"><%= Sidekiq::VERSION %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-processed">実行完了</th>
-                  <td id="sidekiq-processed" class="sidekiq-status-processed"><%= @sidekiq_statuses.processed %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-processes">実行中</th>
-                  <td id="sidekiq-processes" class="sidekiq-status-processes"><%= @sidekiq_statuses.processes_size %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-failed">失敗</th>
-                  <td id="sidekiq-failed" class="sidekiq-status-failed"><%= @sidekiq_statuses.failed %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-scheduled">予定キュー内</th>
-                  <td id="sidekiq-scheduled" class="sidekiq-status-scheduled"><%= @sidekiq_statuses.scheduled_size %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-retry">再試行キュー内</th>
-                  <td id="sidekiq-retry" class="sidekiq-status-retry"><%= @sidekiq_statuses.retry_size %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-dead">デッド状態</th>
-                  <td id="sidekiq-dead" class="sidekiq-status-dead"><%= @sidekiq_statuses.dead_size %></td>
-                </tr>
-                <tr>
-                  <th class="sidekiq-status-workers">ワーカー</th>
-                  <td id="sidekiq-workers" class="sidekiq-status-workers"><%= @sidekiq_statuses.workers_size %></td>
-                </tr>
-              </tbody>
-            </table>
+          <section class="sidekiq-stats">
+            <h2>バックグラウンドジョブ統計</h2>
+            <% if @exception_on_fetching_sidekiq_stats %>
+              <div class="alert alert-danger">
+                <p><%= fa_icon('exclamation-triangle') %> バックグラウンドジョブ統計を取得できませんでした: <%= @exception_on_fetching_sidekiq_stats.message %></p>
+                <p>RedisサーバおよびSidekiqが起動されているか確認してください。</p>
+              </div>
+            <% else %>
+              <table class="table table-striped sidekiq-stats-list">
+                <tbody>
+                  <tr>
+                    <th class="sidekiq-stats-version">Sidekiq バージョン</th>
+                    <td id="sidekiq-version" class="sidekiq-stats-version"><%= Sidekiq::VERSION %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-processed">実行完了</th>
+                    <td id="sidekiq-processed" class="sidekiq-stats-processed"><%= @sidekiq_stats.processed %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-processes">実行中</th>
+                    <td id="sidekiq-processes" class="sidekiq-stats-processes"><%= @sidekiq_stats.processes_size %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-failed">失敗</th>
+                    <td id="sidekiq-failed" class="sidekiq-stats-failed"><%= @sidekiq_stats.failed %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-scheduled">予定キュー内</th>
+                    <td id="sidekiq-scheduled" class="sidekiq-stats-scheduled"><%= @sidekiq_stats.scheduled_size %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-retry">再試行キュー内</th>
+                    <td id="sidekiq-retry" class="sidekiq-stats-retry"><%= @sidekiq_stats.retry_size %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-dead">デッド状態</th>
+                    <td id="sidekiq-dead" class="sidekiq-stats-dead"><%= @sidekiq_stats.dead_size %></td>
+                  </tr>
+                  <tr>
+                    <th class="sidekiq-stats-workers">ワーカー</th>
+                    <td id="sidekiq-workers" class="sidekiq-stats-workers"><%= @sidekiq_stats.workers_size %></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p><%= link_to('詳細を見る（Sidekiq Dashboard）', admin_sidekiq_web_path, class: 'btn btn-success') %></p>
+            <% end %>
           </section>
         </div>
       </div>

--- a/test/integration/admin_status_show_without_redis_test.rb
+++ b/test/integration/admin_status_show_without_redis_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'user_login_test_helper'
+
+# Redisに接続できない場合の「現在の状態」画面の結合テスト
+class AdminStatusShowWithoutRedisTest < ActionDispatch::IntegrationTest
+  setup do
+    create(:setting)
+    @user = create(:user)
+
+    @login_helper = UserLoginTestHelper.new(self, @user, admin_status_path)
+
+    Sidekiq.configure_client do |config|
+      config.redis = { url: 'redis://localhost:63790/0' }
+    end
+  end
+
+  teardown do
+    Sidekiq.configure_client do |config|
+      config.redis = { url: 'redis://localhost:6379/0' }
+    end
+  end
+
+  test 'ログインしている場合、表示される' do
+    @login_helper.assert_successful_login_and_get
+  end
+
+  test 'Redis未起動のエラーメッセージが表示される' do
+    @login_helper.assert_successful_login_and_get
+    assert_select('.sidekiq-stats .alert-danger')
+  end
+end


### PR DESCRIPTION
Sidekiqの導入にあたって、Redisに接続できない場合に管理メニューの「現在の状態」が表示できなくなっていました（`Sidekiq::Stats.new` で失敗するため）。その場合でも画面自体は表示されるようにして、原因を判断しやすくしました。

また、同時に文言やレイアウトも調整しました。

# 正常時

![admin_status_with_redis](https://user-images.githubusercontent.com/2551173/99189264-b7b24c00-27a3-11eb-8f77-38cc4802ad0a.png)

# Redisに接続できない場合

![admin_status_without_redis](https://user-images.githubusercontent.com/2551173/99189538-fb598580-27a4-11eb-9c8c-690d3eb9efbc.png)
