### PR TITLE
期間指定のテストを追加する

### DIFF
--- a/app/models/message_period.rb
+++ b/app/models/message_period.rb
@@ -9,16 +9,16 @@ class MessagePeriod
   # チャンネル識別子
   #
   # パラメータ名の都合で名前がchannelsでも識別子を表すことに注意。
-  # @return [String]
+  # @return [Array<String>]
   attr_accessor :channels
-  # 開始日
+  # 開始日時
   # @return [Time, nil]
   #
   # 名称はGoogle検索に準拠している。
   #
   # セッターでは、Time 型に変換できないときは nil になる。
   attr_reader :since
-  # 終了日
+  # 終了日時
   # @return [Time, nil]
   #
   # 名称はGoogle検索に準拠している。

--- a/test/factories/joins.rb
+++ b/test/factories/joins.rb
@@ -4,5 +4,40 @@ FactoryBot.define do
     irc_user
     timestamp { '2016-04-01 12:34:57 +0900' }
     nick { 'rgrb' }
+
+    # 期間指定用
+    # 複数のチャンネルに送られ得る
+    # => 同時刻でもまとめられない
+
+    factory :join_role_channel_100_20200320023455 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:55 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :join_role_channel_200_20200320023455 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:55 +0900' }
+      nick { 'Role' }
+    end
+
+    # 以下、期間指定のQUITのテストで矛盾しないように
+    # 再JOINする
+
+    factory :join_role_channel_100_20200320023701 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:37:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :join_role_channel_200_20200320023730 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:37:30 +0900' }
+      nick { 'Role' }
+    end
   end
 end

--- a/test/factories/message_periods.rb
+++ b/test/factories/message_periods.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :message_period do
+    channels {
+      %i(channel_100 channel_200).map { |c| create(c).identifier }
+    }
+
+    since { Time.new(2001, 2, 3, 4, 5, 6) }
+
+    # until はRubyの予約語なので、add_attribute で追加する
+    add_attribute(:until) { Time.new(2002, 3, 4, 12, 34, 56) }
+
+    page { 2 }
+  end
+end

--- a/test/factories/nicks.rb
+++ b/test/factories/nicks.rb
@@ -11,5 +11,24 @@ FactoryBot.define do
       nick { 'foo' }
       message { 'bar' }
     end
+
+    # 期間指定用
+    # 同時刻ならば1つにまとめられる
+
+    factory :nick_role_channel_100_20200320023501 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:35:01 +0900' }
+      nick { 'Role' }
+      message { 'Role2' }
+    end
+
+    factory :nick_role_channel_200_20200320023501 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:35:01 +0900' }
+      nick { 'Role' }
+      message { 'Role2' }
+    end
   end
 end

--- a/test/factories/notices.rb
+++ b/test/factories/notices.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     nick { 'rgrb' }
     message { '通知' }
 
+    # メッセージ検索用
+
     factory :notice_toybox_20140320000000 do
       association :irc_user, factory: :irc_user_toybox
       timestamp { '2014-03-20 00:00:00 +0900' }
@@ -18,6 +20,24 @@ FactoryBot.define do
       timestamp { '2014-03-21 00:00:00 +0900' }
       nick { 'Toybox' }
       message { 'Toybox が #irc_test の皆様に 2014年03月21日 00時00分00秒 をお知らせします' }
+    end
+
+    # 期間指定用
+
+    factory :notice_toybox_channel_300_20200320000000 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-20 00:00:00 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox が #チャンネル300 の皆様に 2020年03月20日 00時00分00秒 をお知らせします' }
+    end
+
+    factory :notice_toybox_channel_300_20200321000000 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-21 00:00:00 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox が #チャンネル300 の皆様に 2020年03月21日 00時00分00秒 をお知らせします' }
     end
   end
 end

--- a/test/factories/parts.rb
+++ b/test/factories/parts.rb
@@ -5,5 +5,23 @@ FactoryBot.define do
     timestamp { '2016-04-01 12:34:58 +0900' }
     nick { 'rgrb' }
     message { 'Bye!' }
+
+    # 期間指定用
+    # 複数のチャンネルに送られ得る
+    # => 同時刻でもまとめられない
+
+    factory :part_role_channel_100_20200320023601 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:36:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :part_role_channel_200_20200320023601 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:36:01 +0900' }
+      nick { 'Role' }
+    end
   end
 end

--- a/test/factories/privmsgs.rb
+++ b/test/factories/privmsgs.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     nick { 'rgrb' }
     message { 'プライベートメッセージ' }
 
+    # メッセージ検索用
+
     factory :privmsg_rgrb_20140320012345 do
       timestamp { '2014-03-20 01:23:45 +0900' }
       message { 'RGRB (irc.cre.jp)' }
@@ -24,6 +26,8 @@ FactoryBot.define do
       nick { 'Toybox' }
       message { 'Toybox (irc.cre.jp)' }
     end
+
+    # フラグメント識別子用
 
     # fragment_id: #c190465ea
     factory :privmsg_keyword_sw_k do
@@ -47,6 +51,30 @@ FactoryBot.define do
     factory :privmsg_keyword_sw_zenkaku do
       timestamp { '2019-10-20 01:24:15 +0900' }
       message { '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０' }
+    end
+
+    # 期間指定用
+
+    factory :privmsg_rgrb_channel_100_20200320012345 do
+      association :channel, factory: :channel_100
+      timestamp { '2020-03-20 01:23:45 +0900' }
+      message { 'RGRB (irc.cre.jp)' }
+    end
+
+    factory :privmsg_role_channel_200_20200320023456 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:56 +0900' }
+      nick { 'Role' }
+      message { 'Role (irc.trpg.net)' }
+    end
+
+    factory :privmsg_toybox_channel_300_20200320210954 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-20 21:09:54 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox (irc.cre.jp)' }
     end
   end
 end

--- a/test/factories/quits.rb
+++ b/test/factories/quits.rb
@@ -5,5 +5,24 @@ FactoryBot.define do
     timestamp { '2016-04-01 12:34:59 +0900' }
     nick { 'rgrb' }
     message { 'Bye!' }
+
+    factory :quit_role_channel_100_20200320024001 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:40:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :quit_role_channel_200_20200320024001 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:40:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :quit_rgrb_channel_100_20200321112233 do
+      association :channel, factory: :channel_100
+      timestamp { '2020-03-21 11:22:33 +0900' }
+    end
   end
 end

--- a/test/models/message_period_test.rb
+++ b/test/models/message_period_test.rb
@@ -130,7 +130,27 @@ class MessagePeriodTest < ActiveSupport::TestCase
     assert_equal(5, ConversationMessage.count)
   end
 
-  test '開始日時を指定した場合の検索結果が正しい' do
+  test '開始日時を指定した場合の検索結果が正しい（ConversationMessage）' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = Time.new(2020, 3, 20, 12, 0, 0, '+09:00')
+    @period.until = nil
+    @period.page = 1
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @privmsg_toybox_channel_300_20200320210954,
+        @notice_toybox_channel_300_20200321000000,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test '開始日時を指定した場合の検索結果が正しい（Message）' do
     prepare_messages
 
     @period.channels = []
@@ -146,17 +166,9 @@ class MessagePeriodTest < ActiveSupport::TestCase
       ],
       result.messages.to_a
     )
-
-    assert_equal(
-      [
-        @privmsg_toybox_channel_300_20200320210954,
-        @notice_toybox_channel_300_20200321000000,
-      ],
-      result.conversation_messages.to_a
-    )
   end
 
-  test '終了日時を指定した場合の検索結果が正しい' do
+  test '終了日時を指定した場合の検索結果が正しい（ConversationMessage）' do
     prepare_messages
 
     @period.channels = []
@@ -166,16 +178,8 @@ class MessagePeriodTest < ActiveSupport::TestCase
 
     result = @period.result
 
-    assert_equal(
-      [
-        @join_role_channel_200_20200320023455,
-        @join_role_channel_100_20200320023455,
-        @nick_role_channel_200_20200320023501,
-        @nick_role_channel_100_20200320023501,
-      ],
-      result.messages.to_a
-    )
-
+    # 会話メッセージ
+    # 日時の昇順
     assert_equal(
       [
         @notice_toybox_channel_300_20200320000000,
@@ -186,7 +190,29 @@ class MessagePeriodTest < ActiveSupport::TestCase
     )
   end
 
-  test '開始日時と終了日時の両方を指定した場合の検索結果が正しい' do
+  test '終了日時を指定した場合の検索結果が正しい（Message）' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = nil
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    # （1）日時の昇順、（2）IDの昇順
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @join_role_channel_100_20200320023455,
+        @nick_role_channel_200_20200320023501,
+        @nick_role_channel_100_20200320023501,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test '開始日時と終了日時の両方を指定した場合の検索結果が正しい（ConversationMessage）' do
     prepare_messages
 
     @period.channels = []
@@ -196,14 +222,7 @@ class MessagePeriodTest < ActiveSupport::TestCase
 
     result = @period.result
 
-    assert_equal(
-      [
-        @join_role_channel_200_20200320023455,
-        @join_role_channel_100_20200320023455,
-      ],
-      result.messages.to_a
-    )
-
+    # 日時の昇順
     assert_equal(
       [
         @privmsg_rgrb_channel_100_20200320012345,
@@ -213,7 +232,27 @@ class MessagePeriodTest < ActiveSupport::TestCase
     )
   end
 
-  test 'チャンネルを指定した場合の検索結果が正しい' do
+  test '開始日時と終了日時の両方を指定した場合の検索結果が正しい（Message）' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = Time.new(2020, 3, 20, 1, 0, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 35, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    # IDの昇順
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @join_role_channel_100_20200320023455,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test 'チャンネルを指定した場合の検索結果が正しい（ConversationMessage）' do
     prepare_messages
 
     @period.channels = %w(channel_200 channel_300)
@@ -223,6 +262,28 @@ class MessagePeriodTest < ActiveSupport::TestCase
 
     result = @period.result
 
+    # 日時の昇順
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @privmsg_role_channel_200_20200320023456,
+        @notice_toybox_channel_300_20200321000000,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test 'チャンネルを指定した場合の検索結果が正しい（Message）' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = nil
+    @period.until = nil
+    @period.page = 1
+
+    result = @period.result
+
+    # 日時の昇順
     assert_equal(
       [
         @join_role_channel_200_20200320023455,
@@ -233,18 +294,9 @@ class MessagePeriodTest < ActiveSupport::TestCase
       ],
       result.messages.to_a
     )
-
-    assert_equal(
-      [
-        @notice_toybox_channel_300_20200320000000,
-        @privmsg_role_channel_200_20200320023456,
-        @notice_toybox_channel_300_20200321000000,
-      ],
-      result.conversation_messages.to_a
-    )
   end
 
-  test 'チャンネル、開始日時、終了日時を指定した場合の検索結果が正しい' do
+  test 'チャンネル、開始日時、終了日時を指定した場合の検索結果が正しい（ConversationMessage）' do
     prepare_messages
 
     @period.channels = %w(channel_200 channel_300)
@@ -254,20 +306,33 @@ class MessagePeriodTest < ActiveSupport::TestCase
 
     result = @period.result
 
-    assert_equal(
-      [
-        @join_role_channel_200_20200320023455,
-        @nick_role_channel_200_20200320023501,
-      ],
-      result.messages.to_a
-    )
-
+    # 日時の昇順
     assert_equal(
       [
         @notice_toybox_channel_300_20200320000000,
         @privmsg_role_channel_200_20200320023456,
       ],
       result.conversation_messages.to_a
+    )
+  end
+
+  test 'チャンネル、開始日時、終了日時を指定した場合の検索結果が正しい（Message）' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 0, 0, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @nick_role_channel_200_20200320023501,
+      ],
+      result.messages.to_a
     )
   end
 end

--- a/test/models/message_period_test.rb
+++ b/test/models/message_period_test.rb
@@ -1,0 +1,273 @@
+require 'test_helper'
+
+# 期間指定モデルのテスト
+# @todo NICKやQUITがまとめられることを確認するテストを追加したい。
+class MessagePeriodTest < ActiveSupport::TestCase
+  setup do
+    @period = build(:message_period)
+
+    Message.delete_all
+    ConversationMessage.delete_all
+  end
+
+  teardown do
+    ConversationMessage.delete_all
+    Message.delete_all
+  end
+
+  test '有効である' do
+    assert(@period.valid?)
+  end
+
+  test 'since と until が共に存在する場合、until は since 以上' do
+    @period.since = Time.new(2017, 1, 1)
+
+    @period.until = Time.new(2017, 1, 2)
+    assert(@period.valid?, 'since < until は有効')
+
+    @period.until = Time.new(2017, 1, 1)
+    assert(@period.valid?, 'since == until は有効')
+
+    @period.until = Time.new(2016, 12, 31)
+    refute(@period.valid?, 'since > until は無効')
+  end
+
+  test 'attributes が正しい' do
+    attributes = @period.attributes
+
+    assert_equal(%w(channel_100 channel_200), attributes.fetch('channels'), 'channels')
+    assert_equal(Time.new(2001, 2, 3, 4, 5, 6), attributes.fetch('since'), 'since')
+    assert_equal(Time.new(2002, 3, 4, 12, 34, 56), attributes.fetch('until'), 'until')
+    assert_equal(2, attributes.fetch('page'), 'page')
+  end
+
+  test 'attributes= によって属性が正しく設定される' do
+    %i(channel channel_with_camel_case_name).each do |factory|
+      create(factory)
+    end
+
+    attributes = {
+      'channels' => %w(channel camel_case_channel),
+      'since' => Time.new(2000, 1, 23, 4, 56, 7),
+      'until' => Time.new(2001, 12, 31, 7, 8, 9),
+      'page' => 12
+    }
+
+    @period.attributes = attributes
+
+    assert_equal(attributes['channels'], @period.channels, 'channels')
+    assert_equal(attributes['since'], @period.since, 'since')
+    assert_equal(attributes['until'], @period.until, 'until')
+    assert_equal(attributes['page'], @period.page, 'page')
+  end
+
+  test 'attributes_for_result_page が正しい' do
+    attributes = @period.attributes_for_result_page
+
+    assert_equal('channel_100 channel_200', attributes.fetch('channels'), 'channels')
+    assert_equal('2001-02-03 04:05:06', attributes.fetch('since'), 'since')
+    assert_equal('2002-03-04 12:34:56', attributes.fetch('until'), 'until')
+    assert_equal(2, attributes.fetch('page'), 'page')
+  end
+
+  test 'set_attributes_with_result_page_params によって属性が正しく設定される' do
+    %i(channel channel_with_camel_case_name).each do |factory|
+      create(factory)
+    end
+
+    attributes = {
+      'channels' => 'channel camel_case_channel',
+      'since' => '2000-01-23 04:56:07',
+      'until' => '2001-12-31 07:08:09',
+      'page' => 12
+    }
+
+    @period.set_attributes_with_result_page_params(attributes)
+
+    assert_equal(['channel', 'camel_case_channel'], @period.channels, 'channel')
+    assert_equal(Time.new(2000, 1, 23, 4, 56, 7), @period.since, 'since')
+    assert_equal(Time.new(2001, 12, 31, 7, 8, 9), @period.until, 'until')
+    assert_equal(12, @period.page, 'page')
+  end
+
+  # テストで使うメッセージの準備を行う
+  #
+  # 全体的に通常の逆順にして、IDの影響を見られるようにする。
+  def prepare_messages
+    # Messageの準備
+
+    # 最初のJOIN
+    @join_role_channel_200_20200320023455 = create(:join_role_channel_200_20200320023455)
+    @join_role_channel_100_20200320023455 = create(:join_role_channel_100_20200320023455)
+
+    # NICK
+    @nick_role_channel_200_20200320023501 = create(:nick_role_channel_200_20200320023501)
+    @nick_role_channel_100_20200320023501 = create(:nick_role_channel_100_20200320023501)
+
+    # PART
+    @part_role_channel_200_20200320023601 = create(:part_role_channel_200_20200320023601)
+    @part_role_channel_100_20200320023601 = create(:part_role_channel_100_20200320023601)
+
+    # 2回目のJOIN
+    @join_role_channel_200_20200320023730 = create(:join_role_channel_200_20200320023730)
+    @join_role_channel_100_20200320023701 = create(:join_role_channel_100_20200320023701)
+
+    # QUIT
+    @quit_rgrb_channel_100_20200321112233 = create(:quit_rgrb_channel_100_20200321112233)
+    @quit_role_channel_200_20200320024001 = create(:quit_role_channel_200_20200320024001)
+    @quit_role_channel_100_20200320024001 = create(:quit_role_channel_100_20200320024001)
+
+    # PRIVMSG
+    @privmsg_toybox_channel_300_20200320210954 = create(:privmsg_toybox_channel_300_20200320210954)
+    @privmsg_role_channel_200_20200320023456 = create(:privmsg_role_channel_200_20200320023456)
+    @privmsg_rgrb_channel_100_20200320012345 = create(:privmsg_rgrb_channel_100_20200320012345)
+
+    # NOTICE
+    @notice_toybox_channel_300_20200321000000 = create(:notice_toybox_channel_300_20200321000000)
+    @notice_toybox_channel_300_20200320000000 = create(:notice_toybox_channel_300_20200320000000)
+
+    assert_equal(11, Message.count)
+    assert_equal(5, ConversationMessage.count)
+  end
+
+  test '開始日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = Time.new(2020, 3, 20, 12, 0, 0, '+09:00')
+    @period.until = nil
+    @period.page = 1
+
+    result = @period.result
+
+    assert_equal(
+      [
+        @quit_rgrb_channel_100_20200321112233,
+      ],
+      result.messages.to_a
+    )
+
+    assert_equal(
+      [
+        @privmsg_toybox_channel_300_20200320210954,
+        @notice_toybox_channel_300_20200321000000,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test '終了日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = nil
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @join_role_channel_100_20200320023455,
+        @nick_role_channel_200_20200320023501,
+        @nick_role_channel_100_20200320023501,
+      ],
+      result.messages.to_a
+    )
+
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @privmsg_rgrb_channel_100_20200320012345,
+        @privmsg_role_channel_200_20200320023456,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test '開始日時と終了日時の両方を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = []
+    @period.since = Time.new(2020, 3, 20, 1, 0, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 35, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @join_role_channel_100_20200320023455,
+      ],
+      result.messages.to_a
+    )
+
+    assert_equal(
+      [
+        @privmsg_rgrb_channel_100_20200320012345,
+        @privmsg_role_channel_200_20200320023456,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test 'チャンネルを指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = nil
+    @period.until = nil
+    @period.page = 1
+
+    result = @period.result
+
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @nick_role_channel_200_20200320023501,
+        @part_role_channel_200_20200320023601,
+        @join_role_channel_200_20200320023730,
+        @quit_role_channel_200_20200320024001,
+      ],
+      result.messages.to_a
+    )
+
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @privmsg_role_channel_200_20200320023456,
+        @notice_toybox_channel_300_20200321000000,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+
+  test 'チャンネル、開始日時、終了日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 0, 0, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+    @period.page = 1
+
+    result = @period.result
+
+    assert_equal(
+      [
+        @join_role_channel_200_20200320023455,
+        @nick_role_channel_200_20200320023501,
+      ],
+      result.messages.to_a
+    )
+
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @privmsg_role_channel_200_20200320023456,
+      ],
+      result.conversation_messages.to_a
+    )
+  end
+end


### PR DESCRIPTION
期間指定機能について、メッセージの絞り込みと並び順を中心としたテストを追加しました。…が、全然通りません😥