### PR TITLE
MessagePeriod: 発言表示画面の改良

### DIFF
--- a/app/views/messages/periods/show.html.erb
+++ b/app/views/messages/periods/show.html.erb
@@ -55,32 +55,11 @@
                       </td>
                     </tr>
                   <% end %>
-                  <tr class="message-visibility">
-                    <th scope="row">表示</th>
-                    <td>
-                      <form>
-                        <label class="checkbox-inline">
-                          <input type="checkbox" id="show-speeches" name="show-speeches" checked />
-                          発言
-                        </label>
-                        <label class="checkbox-inline">
-                          <input type="checkbox" id="show-nick" name="show-nick" checked />
-                          ニックネーム変更
-                        </label>
-                        <label class="checkbox-inline">
-                          <input type="checkbox" id="show-join-part" name="show-join-part" />
-                          参加・退出
-                        </label>
-                      </form>
-                    </td>
-                  </tr>
                 </tbody>
               </table>
             </div>
 
             <%= render('shared/message_list', messages: @messages, privmsg_keyword_relationships: @privmsg_keyword_relationships, show_channel: true, style: :normal) %>
-
-            <div class="alert alert-info no-message-to-show">表示するメッセージがありません。</div>
 
             <%= paginate(@conversation_messages, outer_window: 2) %>
           </article>

--- a/app/views/messages/periods/show.html.erb
+++ b/app/views/messages/periods/show.html.erb
@@ -59,7 +59,7 @@
               </table>
             </div>
 
-            <%= render('shared/message_list', messages: @messages, privmsg_keyword_relationships: @privmsg_keyword_relationships, show_channel: true, style: :normal) %>
+            <%= render('shared/message_with_datetime_list', messages: @messages, privmsg_keyword_relationships: @privmsg_keyword_relationships, show_channel: true, style: :normal) %>
 
             <%= paginate(@conversation_messages, outer_window: 2) %>
           </article>


### PR DESCRIPTION
#191 で提案された以下に対応しました。

* JS で表示する発言の制御機能を削除
* 発言の日付が把握しづらい(時刻ではなく日時を表示するように変更)