### PR TITLE
ConversationMessage: インデックスを追加する

### DIFF
--- a/db/migrate/20210207134034_add_indices_to_conversation_messages_202102.rb
+++ b/db/migrate/20210207134034_add_indices_to_conversation_messages_202102.rb
@@ -1,0 +1,5 @@
+class AddIndicesToConversationMessages202102 < ActiveRecord::Migration[6.1]
+  def change
+    add_index :conversation_messages, [:channel_id, :timestamp, :id]
+  end
+end


### PR DESCRIPTION
WHEREでchannel\_idとtimestampを指定し、ORDER BYでtimestampとidを指定する場合に対応するインデックスが設定されておらず、検索が遅くなる場合がありました。