### PR TITLE
期間指定：キーワード欄で発言の日付も表示する

### DIFF
--- a/app/views/messages/periods/show.html.erb
+++ b/app/views/messages/periods/show.html.erb
@@ -47,7 +47,7 @@
                             <li>
                               <%= link_to(sanitize(keyword.display_title), keyword, class: 'channel-day-keyword-link') %>
                               <% privmsgs.each do |m| %>
-                                <%= link_to(m.timestamp.strftime('%T'), "##{m.fragment_id}", class: 'keyword-list-time') %>
+                                <%= link_to(m.timestamp.strftime('%F %T'), "##{m.fragment_id}", class: 'keyword-list-time') %>
                               <% end %>
                             </li>
                           <% end %>

--- a/app/views/shared/_message_with_datetime.html.erb
+++ b/app/views/shared/_message_with_datetime.html.erb
@@ -1,6 +1,6 @@
 <% anchor = m.fragment_id %>
 <% browse_day = ChannelBrowse::Day.new(channel: m.channel, date: m.timestamp.to_date) %>
-<tr class="message message-type-<%= m.type.downcase %>">
+<tr id="<%= anchor %>" class="message message-type-<%= m.type.downcase %>">
   <td class="message-datetime"><%= link_to(m.timestamp.strftime('%F %T'), browse_day.path(anchor: anchor)) %></td>
   <% if show_channel %>
     <td class="message-channel">


### PR DESCRIPTION
期間指定検索結果ページのキーワード欄で、発言の日付も表示するようにしました。これまでは時刻のみ表示されていたので、複数の日を含む期間の場合に、発言日時が分かりにくくなっていました。

また、メッセージ一覧部分でメッセージにアンカーを設定しました。これまでは設定されておらず、キーワード欄から飛べないようになっていました。

<img width="1164" alt="log-archiver-keyword_anchors" src="https://user-images.githubusercontent.com/2551173/107673184-1a4eb180-6cd9-11eb-96cb-6aba7cf3c11f.png">
