### PR TITLE
期間指定検索結果のテストを追加する

### DIFF
--- a/test/factories/joins.rb
+++ b/test/factories/joins.rb
@@ -4,5 +4,40 @@ FactoryBot.define do
     irc_user
     timestamp { '2016-04-01 12:34:57 +0900' }
     nick { 'rgrb' }
+
+    # 期間指定用
+    # 複数のチャンネルに送られ得る
+    # => 同時刻でもまとめられない
+
+    factory :join_role_channel_100_20200320023455 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:55 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :join_role_channel_200_20200320023455 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:55 +0900' }
+      nick { 'Role' }
+    end
+
+    # 以下、期間指定のQUITのテストで矛盾しないように
+    # 再JOINする
+
+    factory :join_role_channel_100_20200320023701 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:37:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :join_role_channel_200_20200320023730 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:37:30 +0900' }
+      nick { 'Role' }
+    end
   end
 end

--- a/test/factories/message_periods.rb
+++ b/test/factories/message_periods.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
 
     # until はRubyの予約語なので、add_attribute で追加する
     add_attribute(:until) { Time.zone.local(2002, 3, 4, 5, 43, 21) }
+
+    limit { 5000 }
   end
 end

--- a/test/factories/nicks.rb
+++ b/test/factories/nicks.rb
@@ -11,5 +11,24 @@ FactoryBot.define do
       nick { 'foo' }
       message { 'bar' }
     end
+
+    # 期間指定用
+    # 同時刻ならば1つにまとめられる
+
+    factory :nick_role_channel_100_20200320023501 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:35:01 +0900' }
+      nick { 'Role' }
+      message { 'Role2' }
+    end
+
+    factory :nick_role_channel_200_20200320023501 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:35:01 +0900' }
+      nick { 'Role' }
+      message { 'Role2' }
+    end
   end
 end

--- a/test/factories/notices.rb
+++ b/test/factories/notices.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     nick { 'rgrb' }
     message { '通知' }
 
+    # メッセージ検索用
+
     factory :notice_toybox_20140320000000 do
       association :irc_user, factory: :irc_user_toybox
       timestamp { '2014-03-20 00:00:00 +0900' }
@@ -18,6 +20,24 @@ FactoryBot.define do
       timestamp { '2014-03-21 00:00:00 +0900' }
       nick { 'Toybox' }
       message { 'Toybox が #irc_test の皆様に 2014年03月21日 00時00分00秒 をお知らせします' }
+    end
+
+    # 期間指定用
+
+    factory :notice_toybox_channel_300_20200320000000 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-20 00:00:00 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox が #チャンネル300 の皆様に 2020年03月20日 00時00分00秒 をお知らせします' }
+    end
+
+    factory :notice_toybox_channel_300_20200321000000 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-21 00:00:00 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox が #チャンネル300 の皆様に 2020年03月21日 00時00分00秒 をお知らせします' }
     end
   end
 end

--- a/test/factories/parts.rb
+++ b/test/factories/parts.rb
@@ -5,5 +5,23 @@ FactoryBot.define do
     timestamp { '2016-04-01 12:34:58 +0900' }
     nick { 'rgrb' }
     message { 'Bye!' }
+
+    # 期間指定用
+    # 複数のチャンネルに送られ得る
+    # => 同時刻でもまとめられない
+
+    factory :part_role_channel_100_20200320023601 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:36:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :part_role_channel_200_20200320023601 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:36:01 +0900' }
+      nick { 'Role' }
+    end
   end
 end

--- a/test/factories/privmsgs.rb
+++ b/test/factories/privmsgs.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     nick { 'rgrb' }
     message { 'プライベートメッセージ' }
 
+    # メッセージ検索用
+
     factory :privmsg_rgrb_20140320012345 do
       timestamp { '2014-03-20 01:23:45 +0900' }
       message { 'RGRB (irc.cre.jp)' }
@@ -24,6 +26,8 @@ FactoryBot.define do
       nick { 'Toybox' }
       message { 'Toybox (irc.cre.jp)' }
     end
+
+    # フラグメント識別子用
 
     # fragment_id: #c190465ea
     factory :privmsg_keyword_sw_k do
@@ -47,6 +51,30 @@ FactoryBot.define do
     factory :privmsg_keyword_sw_zenkaku do
       timestamp { '2019-10-20 01:24:15 +0900' }
       message { '.k　Ｓｗｏｒｄ　Ｗｏｒｌｄ　２．０' }
+    end
+
+    # 期間指定用
+
+    factory :privmsg_rgrb_channel_100_20200320012345 do
+      association :channel, factory: :channel_100
+      timestamp { '2020-03-20 01:23:45 +0900' }
+      message { 'RGRB (irc.cre.jp)' }
+    end
+
+    factory :privmsg_role_channel_200_20200320023456 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:34:56 +0900' }
+      nick { 'Role' }
+      message { 'Role (irc.trpg.net)' }
+    end
+
+    factory :privmsg_toybox_channel_300_20200320210954 do
+      association :channel, factory: :channel_300
+      association :irc_user, factory: :irc_user_toybox
+      timestamp { '2020-03-20 21:09:54 +0900' }
+      nick { 'Toybox' }
+      message { 'Toybox (irc.cre.jp)' }
     end
   end
 end

--- a/test/factories/quits.rb
+++ b/test/factories/quits.rb
@@ -5,5 +5,27 @@ FactoryBot.define do
     timestamp { '2016-04-01 12:34:59 +0900' }
     nick { 'rgrb' }
     message { 'Bye!' }
+
+    factory :quit_rgrb_channel_100_20200321112233 do
+      association :channel, factory: :channel_100
+      timestamp { '2020-03-21 11:22:33 +0900' }
+    end
+
+    # 期間指定用
+    # 同時刻ならば1つにまとめられる
+
+    factory :quit_role_channel_100_20200320024001 do
+      association :channel, factory: :channel_100
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:40:01 +0900' }
+      nick { 'Role' }
+    end
+
+    factory :quit_role_channel_200_20200320024001 do
+      association :channel, factory: :channel_200
+      association :irc_user, factory: :irc_user_role
+      timestamp { '2020-03-20 02:40:01 +0900' }
+      nick { 'Role' }
+    end
   end
 end

--- a/test/models/message_period_test.rb
+++ b/test/models/message_period_test.rb
@@ -222,4 +222,36 @@ class MessagePeriodTest < ActiveSupport::TestCase
       result.messages.to_a
     )
   end
+
+  test '該当件数が上限に達しなければnum_of_messages_limited?は偽' do
+    prepare_messages
+
+    @period.channels = %w(channel_100 channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 0, 0, 0, '+09:00')
+    @period.until = nil
+    @period.limit = 5000
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    assert_equal(14, result.messages.length)
+    refute(result.num_of_messages_limited?)
+  end
+
+  test '該当件数が上限に達したならばnum_of_messages_limited?は真' do
+    prepare_messages
+
+    @period.channels = %w(channel_100 channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 0, 0, 0, '+09:00')
+    @period.until = nil
+    @period.limit = 10
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    assert_equal(10, result.messages.length)
+    assert(result.num_of_messages_limited?)
+  end
 end

--- a/test/models/message_period_test.rb
+++ b/test/models/message_period_test.rb
@@ -74,4 +74,152 @@ class MessagePeriodTest < ActiveSupport::TestCase
     assert_equal(attributes['since'], @period.since, 'since')
     assert_equal(attributes['until'], @period.until, 'until')
   end
+
+  # テストで使うメッセージの準備を行う
+  #
+  # 全体的に通常の逆順にして、IDの影響を見られるようにする。
+  def prepare_messages
+    # Messageの準備
+
+    # 最初のJOIN
+    @join_role_channel_200_20200320023455 = create(:join_role_channel_200_20200320023455)
+    @join_role_channel_100_20200320023455 = create(:join_role_channel_100_20200320023455)
+
+    # NICK
+    @nick_role_channel_200_20200320023501 = create(:nick_role_channel_200_20200320023501)
+    @nick_role_channel_100_20200320023501 = create(:nick_role_channel_100_20200320023501)
+
+    # PART
+    @part_role_channel_200_20200320023601 = create(:part_role_channel_200_20200320023601)
+    @part_role_channel_100_20200320023601 = create(:part_role_channel_100_20200320023601)
+
+    # 2回目のJOIN
+    @join_role_channel_200_20200320023730 = create(:join_role_channel_200_20200320023730)
+    @join_role_channel_100_20200320023701 = create(:join_role_channel_100_20200320023701)
+
+    # QUIT
+    @quit_rgrb_channel_100_20200321112233 = create(:quit_rgrb_channel_100_20200321112233)
+    @quit_role_channel_200_20200320024001 = create(:quit_role_channel_200_20200320024001)
+    @quit_role_channel_100_20200320024001 = create(:quit_role_channel_100_20200320024001)
+
+    # PRIVMSG
+    @privmsg_toybox_channel_300_20200320210954 = create(:privmsg_toybox_channel_300_20200320210954)
+    @privmsg_role_channel_200_20200320023456 = create(:privmsg_role_channel_200_20200320023456)
+    @privmsg_rgrb_channel_100_20200320012345 = create(:privmsg_rgrb_channel_100_20200320012345)
+
+    # NOTICE
+    @notice_toybox_channel_300_20200321000000 = create(:notice_toybox_channel_300_20200321000000)
+    @notice_toybox_channel_300_20200320000000 = create(:notice_toybox_channel_300_20200320000000)
+
+    assert_equal(11, Message.count)
+    assert_equal(5, ConversationMessage.count)
+  end
+
+  test 'チャンネルと開始日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 12, 0, 0, '+09:00')
+    @period.until = nil
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @privmsg_toybox_channel_300_20200320210954,
+        @notice_toybox_channel_300_20200321000000,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test 'チャンネルと終了日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = nil
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    # 会話メッセージ
+    # 日時の昇順
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @join_role_channel_200_20200320023455,
+        @privmsg_role_channel_200_20200320023456,
+        @nick_role_channel_200_20200320023501,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test 'チャンネル、開始日時、終了日時を指定した場合の検索結果が正しい' do
+    prepare_messages
+
+    @period.channels = %w(channel_200 channel_300)
+    @period.since = Time.new(2020, 3, 20, 0, 0, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 36, 0, '+09:00')
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @notice_toybox_channel_300_20200320000000,
+        @join_role_channel_200_20200320023455,
+        @privmsg_role_channel_200_20200320023456,
+        @nick_role_channel_200_20200320023501,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test '同時刻のNICKが1つにまとめられる' do
+    prepare_messages
+
+    @period.channels = %w(channel_100 channel_200)
+    @period.since = Time.new(2020, 3, 20, 2, 35, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 35, 2, '+09:00')
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @nick_role_channel_200_20200320023501,
+      ],
+      result.messages.to_a
+    )
+  end
+
+  test '同時刻のQUITが1つにまとめられる' do
+    prepare_messages
+
+    @period.channels = %w(channel_100 channel_200)
+    @period.since = Time.new(2020, 3, 20, 2, 40, 0, '+09:00')
+    @period.until = Time.new(2020, 3, 20, 2, 40, 2, '+09:00')
+
+    assert(@period.valid?, '検索条件が有効')
+
+    result = @period.result
+
+    # 日時の昇順
+    assert_equal(
+      [
+        @quit_role_channel_200_20200320024001,
+      ],
+      result.messages.to_a
+    )
+  end
 end


### PR DESCRIPTION
期間指定検索が正しくできるか確認する、モデルのテストを追加します。

テストにあたって、件数制限ができるか確かめるために、上限数を変更できるように変えたいです。
→変えて、正常動作を確認できました。