### PR TITLE
Mroonga 10.11への対応を追加する

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
       TZ: Asia/Tokyo
     services:
       db:
-        image: groonga/mroonga:mysql5732_mroonga1010
+        image: groonga/mroonga:latest
         ports:
           - 33060:3306
       redis:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,10 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
+        mroonga:
+          - latest
+          - mysql80-latest
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
     env:
@@ -24,7 +28,7 @@ jobs:
       TZ: Asia/Tokyo
     services:
       db:
-        image: groonga/mroonga:latest
+        image: groonga/mroonga:${{ matrix.mroonga }}
         ports:
           - 33060:3306
       redis:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       TZ: Asia/Tokyo
     services:
       db:
-        image: groonga/mroonga:mysql5732_mroonga1010
+        image: groonga/mroonga:latest
         ports:
           - 33060:3306
       redis:

--- a/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
+++ b/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
@@ -9,6 +9,9 @@ class RecreateConversationMessagesIrcUserId < ActiveRecord::Migration[4.2]
       id_irc_user_id_pairs[cm.irc_user_id] << cm.id
     end
 
+    print_phase('外部キー制約の削除: channel_last_speeches -> conversation_messages')
+    remove_foreign_key :channel_last_speeches, :conversation_messages
+
     print_phase('テーブルの変更')
     change_table :conversation_messages do |t|
       t.remove :irc_user_id
@@ -22,6 +25,11 @@ class RecreateConversationMessagesIrcUserId < ActiveRecord::Migration[4.2]
 
     print_phase('irc_user_id のインデックスの再構築')
     add_index :conversation_messages, :irc_user_id
+
+    print_phase('外部キー制約の復元: channel_last_speeches -> conversation_messages')
+    add_foreign_key(:channel_last_speeches,
+                    :conversation_messages,
+                    name: 'conversation_message_id')
   end
 
   def down

--- a/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
+++ b/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
@@ -10,7 +10,11 @@ class RecreateConversationMessagesIrcUserId < ActiveRecord::Migration[4.2]
     end
 
     print_phase('外部キー制約の削除: channel_last_speeches -> conversation_messages')
-    remove_foreign_key :channel_last_speeches, :conversation_messages
+    if foreign_key_exists?(:channel_last_speeches, :conversation_messages)
+      remove_foreign_key :channel_last_speeches, :conversation_messages
+    else
+      puts('channel_last_speeches -> conversation_messages の外部キー制約は存在しません')
+    end
 
     print_phase('テーブルの変更')
     change_table :conversation_messages do |t|

--- a/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
+++ b/db/migrate/20170617130524_recreate_conversation_messages_irc_user_id.rb
@@ -1,30 +1,39 @@
 class RecreateConversationMessagesIrcUserId < ActiveRecord::Migration[4.2]
   def up
-    puts('[irc_user_id の退避]')
+    @print_phase_separate = false
+
+    print_phase('irc_user_id の退避')
     id_irc_user_id_pairs = {}
     ConversationMessage.where.not(irc_user_id: 0).find_each do |cm|
       id_irc_user_id_pairs[cm.irc_user_id] ||= []
       id_irc_user_id_pairs[cm.irc_user_id] << cm.id
     end
 
-    puts
-    puts('[テーブルの変更]')
+    print_phase('テーブルの変更')
     change_table :conversation_messages do |t|
       t.remove :irc_user_id
       t.integer :irc_user_id, null: false, default: 0
     end
 
-    puts
-    puts('[irc_user_id の復元]')
+    print_phase('irc_user_id の復元')
     id_irc_user_id_pairs.each do |irc_user_id, cm_ids|
       ConversationMessage.where(id: cm_ids).update_all(irc_user_id: irc_user_id)
     end
 
-    puts
-    puts('[irc_user_id のインデックスの再構築]')
+    print_phase('irc_user_id のインデックスの再構築')
     add_index :conversation_messages, :irc_user_id
   end
 
   def down
+  end
+
+  private
+
+  # 進捗表示：段階を表示する
+  def print_phase(name)
+    puts if @print_phase_separate
+    puts("[#{name}]")
+
+    @print_phase_separate = true
   end
 end


### PR DESCRIPTION
Mroonga 10.11を使った場合でもデータベースのマイグレーションが最後まで進むように直しました。

Mroonga 10.11ではインプレースの `ALTER TABLE` の挙動が変わってエラーが発生するようになっていました。このエラーは `channel_last_speeches` -> `conversation_messages` の外部キー制約があると発生しました。そこで、`ALTER TABLE conversation_messages` の前にこの外部キー制約を削除するようにして、エラーを防ぎました。