### PR TITLE
Sorcery 0.16.0を使う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,8 +75,7 @@ gem 'friendly_id'
 gem 'simple_enum'
 
 # 認証
-# @todo https://github.com/Sorcery/sorcery/pull/241 が取り込まれたらmasterを指定しない
-gem 'sorcery', github: 'Sorcery/sorcery', branch: 'master'
+gem 'sorcery'
 
 # 並び替え
 gem 'ranked-model'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/Sorcery/sorcery.git
-  revision: 43efa3329e61d3fff8a5233d9efdc90db6820362
-  branch: master
-  specs:
-    sorcery (0.16.0)
-      bcrypt (~> 3.1)
-      oauth (~> 0.4, >= 0.4.4)
-      oauth2 (~> 1.0, >= 0.8.0)
-
-GIT
   remote: https://github.com/cre-ne-jp/rinku.git
   revision: 5da355a50ec64537a28f75b9cd76e9a0ad78616a
   branch: without-www
@@ -322,6 +312,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sorcery (0.16.0)
+      bcrypt (~> 3.1)
+      oauth (~> 0.4, >= 0.4.4)
+      oauth2 (~> 1.0, >= 0.8.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -423,7 +417,7 @@ DEPENDENCIES
   simple_calendar (~> 2.0)
   simple_enum
   simplecov (~> 0.10, < 0.18)
-  sorcery!
+  sorcery
   spring
   sysexits
   test-unit-rails
@@ -434,4 +428,4 @@ DEPENDENCIES
   xmlrpc
 
 BUNDLED WITH
-   2.2.11
+   2.2.14


### PR DESCRIPTION
https://github.com/Sorcery/sorcery/pull/241 の変更が取り込まれたので、masterブランチの指定が不要になりました。