### PR TITLE
Font Awesomeのアイコンおよび日付選択画面が正しく表示されない問題を修正する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,4 @@
 // "bootstrap-sprockets" must be imported before "bootstrap" and "bootstrap/variables"
-$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
-@import '@fortawesome/fontawesome-free/scss/fontawesome';
-@import '@fortawesome/fontawesome-free/scss/regular';
-@import '@fortawesome/fontawesome-free/scss/solid';
-@import '@fortawesome/fontawesome-free/scss/brands';
-
 @import "bootstrap-sprockets";
 @import "variables";
 @import "bootstrap";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,6 +16,7 @@
 // const imagePath = (name) => images(name, true)
 
 import "./use_flatpickr";
+import "./use_fontawesome";
 
 import { Application } from "stimulus";
 import { definitionsFromContext } from "stimulus/webpack-helpers";

--- a/app/javascript/packs/use_fontawesome.js
+++ b/app/javascript/packs/use_fontawesome.js
@@ -1,0 +1,54 @@
+/* eslint no-console:0 */
+
+import { dom, library } from "@fortawesome/fontawesome-svg-core";
+
+import {
+  faArrowRight,
+  faArrowsAltH,
+  faCalendar,
+  faCheck,
+  faChevronLeft,
+  faChevronRight,
+  faCog,
+  faComments,
+  faExclamationTriangle,
+  faFolderOpen,
+  faInfoCircle,
+  faKey,
+  faPencilAlt,
+  faQuestionCircle,
+  faSearch,
+  faSignInAlt,
+  faSignOutAlt,
+  faTimes,
+  faUser,
+} from "@fortawesome/free-solid-svg-icons";
+
+import {
+  faCreativeCommons,
+} from "@fortawesome/free-brands-svg-icons";
+
+library.add(
+  faArrowRight,
+  faArrowsAltH,
+  faCalendar,
+  faCheck,
+  faChevronLeft,
+  faChevronRight,
+  faCog,
+  faComments,
+  faCreativeCommons,
+  faExclamationTriangle,
+  faFolderOpen,
+  faInfoCircle,
+  faKey,
+  faPencilAlt,
+  faQuestionCircle,
+  faSearch,
+  faSignInAlt,
+  faSignOutAlt,
+  faTimes,
+  faUser,
+);
+
+dom.watch();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <% set_meta_tags(canonical: @canonical_url) if @canonical_url %>
     <%= display_meta_tags(default_meta_tags) %>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= stylesheet_pack_tag 'application' %>
     <%= javascript_pack_tag 'application' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>

--- a/lib/tasks/fontawesome.rake
+++ b/lib/tasks/fontawesome.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :fontawesome do
+  desc '使用中のFont Awesomeアイコンを一覧表示する'
+  task :list do
+    grep_result = `git grep -o -P "\\bfa_icon\\('[^']+'"`
+    icons = grep_result.each_line.map { |l| (l.match(/'([^']+)'/).to_a)[1] }
+    puts(icons.compact.sort.uniq)
+  end
+end

--- a/lib/tasks/fontawesome.rake
+++ b/lib/tasks/fontawesome.rake
@@ -3,8 +3,27 @@
 namespace :fontawesome do
   desc '使用中のFont Awesomeアイコンを一覧表示する'
   task :list do
+    puts(used_fontawesome_icons)
+  end
+
+  desc 'Font Awesomeアイコンを使用するためのJavaScriptを出力する'
+  task :js_config do
+    items_for_import = used_fontawesome_icons.map { |i| "fa#{i.underscore.camelize}" }
+    ERB.new(USE_FONTAWESOME_JS_ERB, trim_mode: 2).run(binding)
+  end
+
+  def used_fontawesome_icons
     grep_result = `git grep -o -P "\\bfa_icon\\('[^']+'"`
     icons = grep_result.each_line.map { |l| (l.match(/'([^']+)'/).to_a)[1] }
-    puts(icons.compact.sort.uniq)
+
+    icons.compact.sort.uniq
   end
+
+  USE_FONTAWESOME_JS_ERB = <<~ERB
+    library.add(
+    <% items_for_import.each do |i| %>
+      <%= i %>,
+    <% end %>
+    );
+  ERB
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.2",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-brands-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@rails/webpacker": "5.2.1",
     "flatpickr": "^4.6.9",
     "stimulus": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,31 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-free@^5.15.2":
-  version "5.15.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.2.tgz#218cd7276ab4f9ab57cc3d2efa2697e6a579f25d"
-  integrity sha512-7l/AX41m609L/EXI9EKH3Vs3v0iA8tKlIOGtw+kgcoanI7p+e4I4GYLqW3UXWiTnjSFymKSmTTPKYrivzbxxqA==
+"@fortawesome/fontawesome-common-types@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
+  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+
+"@fortawesome/fontawesome-svg-core@^1.2.35":
+  version "1.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz#85aea8c25645fcec88d35f2eb1045c38d3e65cff"
+  integrity sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/free-brands-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.3.tgz#bec2821d23b9c667be1d192a6c5bfb2667e588eb"
+  integrity sha512-1hirPcbjj72ZJtFvdnXGPbAbpn3Ox6mH3g5STbANFp3vGSiE5u5ingAKV06mK6ZVqNYxUPlh4DlTnaIvLtF2kw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/free-solid-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"
+  integrity sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
 
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"


### PR DESCRIPTION
Production環境においてFont Awesomeのアイコンおよび日付選択画面が正しく表示されない問題を修正しました。

# Font Awesomeのアイコン

`rails assets:precompile` でコンパイルしたアセットを使用する場合には、フォントファイルがSCSSで指定されたパスに出力されていなかったため、正しく表示されていませんでした。そこで、以下の記事を参考にして、JavaScript経由で使用する場合に向いているSVG版を使うように変えました。こちらはWebpack内で完結するため、読み込みの問題が発生しません。

https://qiita.com/riversun/items/4faa56ac40071f638313

# 日付選択画面

日付選択画面で使用しているflatpickr用のスタイルが読み込まれず、正しく表示されない問題を修正しました。`production` 環境において実行した `rails assets:precompile` の出力を調べると、`public/packs/css/application-*.css` も出力されており、このファイルの読み込みも必要でした。そのため、レイアウトファイルで `stylesheet_pack_tag 'application'` を使用して読み込むようにしました。