### PR TITLE
メッセージの詳細アイコンの表示を修正する

### DIFF
--- a/app/views/shared/_message.html.erb
+++ b/app/views/shared/_message.html.erb
@@ -39,9 +39,9 @@
     <td class="message-detail">
       <% if MessageHelper::PossibleArchiveTypes.include?(m.type) %>
         <% if m.kind_of?(ArchivedConversationMessage) %>
-          <%= link_to(fa_icon('info-circle', text: '詳細'), admin_archived_conversation_message_path(m.id)) %>
+          <%= link_to(fa_icon('info-circle', title: '詳細'), admin_archived_conversation_message_path(m.id)) %>
         <% else %>
-          <%= link_to(fa_icon('info-circle', text: '詳細'), admin_conversation_message_path(m.id)) %>
+          <%= link_to(fa_icon('info-circle', title: '詳細'), admin_conversation_message_path(m.id)) %>
         <% end %>
       <% end %>
     </td>


### PR DESCRIPTION
Font Awesome 5導入時にタグが誤って変更されたため、「詳細」というテキストが表示され、レイアウトが崩れていたのを修正しました。

修正前：
<img width="111" alt="message_details_icon1" src="https://user-images.githubusercontent.com/2551173/111880235-8cf43080-89ed-11eb-8e3f-a48dd9895c5c.png">

修正後：
<img width="81" alt="message_details_icon2" src="https://user-images.githubusercontent.com/2551173/111880238-954c6b80-89ed-11eb-983a-ae6f9fcd1a6a.png">
