### PR TITLE
MircToHtml: テストを追加する

### DIFF
--- a/lib/log_archiver/mirc_to_html.rb
+++ b/lib/log_archiver/mirc_to_html.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 module LogArchiver
+  # mIRC 制御文字による装飾を含むメッセージを、HTML に変換する
+  # @see https://www.mirc.co.uk/colors.html
+  # @see https://www.mirc.com/help/html/index.html?control_codes.html
+  # @see https://yoshino.tripod.com/73th/data/irccode.htm#ascii_controlcode
+  # @see https://en.wikichip.org/wiki/irc/colors
   class MircToHtml
-    # mIRC 制御文字による装飾を含むメッセージを、HTML に変換する
-    # @see https://www.mirc.co.uk/colors.html
-    # @see https://www.mirc.com/help/html/index.html?control_codes.html
-    # @see https://yoshino.tripod.com/73th/data/irccode.htm#ascii_controlcode
-    # @see https://en.wikichip.org/wiki/irc/colors
-
     # コンストラクタ
     # @param [String] mirc mIRC 形式の制御文字を含みうるメッセージ
     # @param [String] html_class_header HTMLタグに付加するクラスの接頭辞

--- a/test/lib/log_archiver/mirc_to_html_test.rb
+++ b/test/lib/log_archiver/mirc_to_html_test.rb
@@ -101,7 +101,7 @@ module LogArchiver
 
     data '色指定: 背景色を維持して文字色のみ変更', [
       "ここから\x0300,01文字白色, 背景黒色\x0315, 文字明るいグレー, 背景黒色",
-      'ここから<span class="mirc-color00 mirc-bg01">文字白色, 背景黒色</span><span class="mirc-color15 mirc-bg01">, 文字明るいグレー, 背景黒色</span>'
+      'ここから<span class="mirc-color00 mirc-bg01">文字白色, 背景黒色</span><span class="mirc-bg01 mirc-color15">, 文字明るいグレー, 背景黒色</span>'
     ]
 
     data 'IRC Formatting Example 1', [

--- a/test/lib/log_archiver/mirc_to_html_test.rb
+++ b/test/lib/log_archiver/mirc_to_html_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module LogArchiver
+  class MircToHtmlTest < ActiveSupport::TestCase
+    data '太字', [
+      "これは \x02太字\x02 です。",
+      'これは <span class="mirc-bold">太字</span> です。'
+    ]
+
+    data '斜体', [
+      "これは \x1D斜体\x1D です。",
+      'これは <span class="mirc-italic">斜体</span> です。'
+    ]
+
+    data '下線', [
+      "以下に\x1F下線が引かれます\x1F。",
+      '以下に<span class="mirc-underline">下線が引かれます</span>。'
+    ]
+
+    data '打ち消し', [
+      "以下は\x1E打ち消されます\x1E。",
+      '以下は<span class="mirc-strikethrough">打ち消されます</span>。',
+    ]
+
+    data '等幅', [
+      "Rubyでは \x11puts()\x11 で文字列を出力できます。",
+      'Rubyでは <span class="mirc-monospace">puts()</span> で文字列を出力できます。'
+    ]
+
+    data '太字＋斜体＋下線', [
+      "重ねて装飾: \x02太字 \x1D斜体 \x1F下線 \x1F下線解除 \x02太字解除 \x1D装飾なし",
+      '重ねて装飾: <span class="mirc-bold">太字 </span><span class="mirc-bold mirc-italic">斜体 </span><span class="mirc-bold mirc-italic mirc-underline">下線 </span><span class="mirc-bold mirc-italic">下線解除 </span><span class="mirc-italic">太字解除 </span>装飾なし'
+    ]
+
+    data 'リセット', [
+      "重ねて装飾: \x02太字 \x1D斜体 \x1F下線 \x0Fまとめてリセット",
+      '重ねて装飾: <span class="mirc-bold">太字 </span><span class="mirc-bold mirc-italic">斜体 </span><span class="mirc-bold mirc-italic mirc-underline">下線 </span>まとめてリセット'
+    ]
+
+    data '色指定: リセット', [
+      "制御文字\x03のみでリセット",
+      '制御文字のみでリセット',
+    ]
+
+    data '色指定: 文字色1桁', [
+      "これは \x030白色\x03 です。",
+      'これは <span class="mirc-color00">白色</span> です。'
+    ]
+
+    data '色指定: 文字色2桁', [
+      "これは \x0301黒色\x03 です。",
+      'これは <span class="mirc-color01">黒色</span> です。'
+    ]
+
+    data '色指定: 文字色2桁、その後すぐ数字', [
+      "これは \x030123黒色\x03 です。",
+      'これは <span class="mirc-color01">23黒色</span> です。'
+    ]
+
+    data '色指定: カンマのみ', [
+      "制御文字後\x03, カンマのみはリセット",
+      '制御文字後, カンマのみはリセット'
+    ]
+
+    data '色指定: 文字色1桁の後カンマ', [
+      "これは\x030,白色\x03です。",
+      'これは<span class="mirc-color00">,白色</span>です。'
+    ]
+
+    data '色指定: 文字色2桁の後カンマ', [
+      "これは\x0301,黒色\x03です。",
+      'これは<span class="mirc-color01">,黒色</span>です。'
+    ]
+
+    data '色指定: 文字色1桁、背景色1桁', [
+      "これは \x030,1文字白色, 背景黒色\x03 です。",
+      'これは <span class="mirc-color00 mirc-bg01">文字白色, 背景黒色</span> です。'
+    ]
+
+    data '色指定: 文字色1桁、背景色2桁', [
+      "これは \x031,00文字黒色, 背景白色\x03 です。",
+      'これは <span class="mirc-color01 mirc-bg00">文字黒色, 背景白色</span> です。'
+    ]
+
+    data '色指定: 文字色2桁、背景色1桁', [
+      "これは \x0300,1文字白色, 背景黒色\x03 です。",
+      'これは <span class="mirc-color00 mirc-bg01">文字白色, 背景黒色</span> です。'
+    ]
+
+    data '色指定: 文字色2桁、背景色2桁', [
+      "これは \x0301,00文字黒色, 背景白色\x03 です。",
+      'これは <span class="mirc-color01 mirc-bg00">文字黒色, 背景白色</span> です。'
+    ]
+
+    data '制御文字後にカンマ数字はリセット', [
+      "背景色が\x0300,01設定されそうで\x03,02されない",
+      '背景色が<span class="mirc-color00 mirc-bg01">設定されそうで</span>,02されない'
+    ]
+
+    data '色指定: 背景色を維持して文字色のみ変更', [
+      "ここから\x0300,01文字白色, 背景黒色\x0315, 文字明るいグレー, 背景黒色",
+      'ここから<span class="mirc-color00 mirc-bg01">文字白色, 背景黒色</span><span class="mirc-color15 mirc-bg01">, 文字明るいグレー, 背景黒色</span>'
+    ]
+
+    data 'IRC Formatting Example 1', [
+      "I love \x033IRC! \x03It is the \x037best protocol ever!",
+      'I love <span class="mirc-color03">IRC! </span>It is the <span class="mirc-color07">best protocol ever!</span>'
+    ]
+
+    data 'IRC Formatting Example 2', [
+      "This is a \x1D\x0313,9cool \x03message",
+      'This is a <span class="mirc-italic mirc-color13 mirc-bg09">cool </span><span class="mirc-italic">message</span>'
+    ]
+
+    data 'IRC Formatting Example 3', [
+      "IRC \x02is \x034,12so \x03great\x0F!",
+      'IRC <span class="mirc-bold">is </span><span class="mirc-bold mirc-color04 mirc-bg12">so </span><span class="mirc-bold">great</span>!'
+    ]
+
+    data 'IRC Formatting Example 4', [
+      "Rules: Don't spam 5\x0313,8,6\x03,7,8, and especially not \x029\x02\x1D!",
+      %q|Rules: Don't spam 5<span class="mirc-color13 mirc-bg08">,6</span>,7,8, and especially not <span class="mirc-bold">9</span><span class="mirc-italic">!</span>|
+    ]
+
+    data '#openTRPG 2019-04-29', [
+      "\x0311,11\x0311,0\x0311,0",
+      ''
+    ]
+
+    test 'mIRC制御文字が正しくHTMLに変換される' do
+      text_with_mirc_codes, expected = data
+
+      html = MircToHtml.new(text_with_mirc_codes).convert
+      assert_equal(expected, html)
+    end
+  end
+end


### PR DESCRIPTION
変換処理のテストを追加しました。その装飾だけを試す簡単なテストケースから、複数の装飾を重ねるなど複雑なテストケースまで含まれています。