### PR TITLE
MircToHtml: デザイン調整: Material Colorsを適用する

### DIFF
--- a/app/assets/stylesheets/_bootswatch.scss
+++ b/app/assets/stylesheets/_bootswatch.scss
@@ -97,24 +97,6 @@ table,
       color: #fff;
     }
   }
-
-  > thead > tr > th,
-  > tbody > tr > th,
-  > tfoot > tr > th,
-  > thead > tr > td,
-  > tbody > tr > td,
-  > tfoot > tr > td {
-    border: none;
-  }
-
-  &-bordered > thead > tr > th,
-  &-bordered > tbody > tr > th,
-  &-bordered > tfoot > tr > th,
-  &-bordered > thead > tr > td,
-  &-bordered > tbody > tr > td,
-  &-bordered > tfoot > tr > td {
-    border: 1px solid $table-border-color;
-  }
 }
 
 // Forms ======================================================================

--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -230,9 +230,9 @@ table.message-list {
   }
 }
 
-table {
+table.message-list {
   .odd {
-    background-color: $table-bg-accent;
+    background-color: lighten($table-bg-accent, 5%);
   }
 }
 

--- a/app/assets/stylesheets/_mirc-html.scss
+++ b/app/assets/stylesheets/_mirc-html.scss
@@ -1,23 +1,24 @@
 // 下記の色指定は mIRC のヘルプページを参考にした (2021-05-08参照)
 // @see: https://www.mirc.com/help/html/index.html?control_codes.html
+// @see: https://material.io/design/color/the-color-system.html#tools-for-picking-colors
 // @see: https://modern.ircdocs.horse/formatting.html#colors-16-98
 $color-codes: (
   "00": #FFFFFF,  // white
   "01": #000000,  // black
-  "02": #00007F,  // blue
-  "03": #009300,  // green
-  "04": #FF0000,  // red
-  "05": #7F0000,  // brown
-  "06": #9C009C,  // purple (magenta)
-  "07": #FC7C00,  // orange
-  "08": #FFFF00,  // yellow
-  "09": #00FC00,  // light green
-  "10": #009393,  // cyan
-  "11": #00FFFF,  // light cyan
-  "12": #0000FC,  // light blue
-  "13": #FF00FF,  // pink
-  "14": #7F7F7F,  // grey
-  "15": #D2D2D2,  // light grey
+  "02": #283593,  // blue -> Indigo 800
+  "03": #43A047,  // green -> Green 600
+  "04": #FF3D00,  // red -> Deep Orange A400
+  "05": #6D4C41,  // brown -> Brown 600
+  "06": #8E24AA,  // purple (magenta) -> Purple 600
+  "07": #FB8C00,  // orange -> Orange 600
+  "08": #FFEB3B,  // yellow -> Yellow 500
+  "09": #76FF03,  // light green -> Light Green A400
+  "10": #009688,  // cyan -> Teal 500
+  "11": #18FFFF,  // light cyan -> Cyan A200
+  "12": #304FFE,  // light blue -> Indigo A700
+  "13": #FF4081,  // pink -> Pink A200
+  "14": #757575,  // grey -> Grey 600
+  "15": #BDBDBD,  // light grey -> Grey 400
 
   "16": #470000,
   "17": #472100,


### PR DESCRIPTION
IRCメッセージの色設定部分の色を調整しました。

* mIRCのスタイルを参考にしながら[Material Designの色パレット](https://material.io/design/color/the-color-system.html#tools-for-picking-colors)より色を選び、原色のキツさを和らげました。
* メッセージ表示部分のストライプのグレーを明るくしました。これまでは濃いめの色で、15番のlight greyと区別しにくいものでした。
* Bootstrapの標準スタイルと同様に、表の罫線が表示されるようにしました。表の色の調整時に、罫線がある方が見やすく感じました。

<img width="204" alt="mirc_text_colors-log_archiver" src="https://user-images.githubusercontent.com/2551173/120094645-9243c900-c15c-11eb-8c68-60d5b1bf7567.png">

<img width="200" alt="mirc_bg_colors-log_archiver" src="https://user-images.githubusercontent.com/2551173/120094651-996ad700-c15c-11eb-9160-8beee82df4aa.png">
