### PR TITLE
Ruby 2.7未満のサポート終了

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
-          - 2.6
           - 2.7
           - 3.0
         mroonga:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ IRC ボットを常駐させることでチャットログをチャンネル単�
 ## 動作環境
 
 * Linux または OSX
-* Ruby 2.3.0 以降
+* Ruby 2.7.0 以降
 * MySQL または MariaDB
 * Redis
 


### PR DESCRIPTION
Fixes #280

Ruby 2.6が2021-04-05をもってセキュリティメンテナンスフェーズに
移行したため。

https://www.ruby-lang.org/ja/news/2021/04/05/ruby-2-6-7-released/