### PR TITLE
.a で出力した Amazon アフィリエイトタグを、任意のタグに差し替える

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -24,6 +24,6 @@ class SettingsController < ApplicationController
   def setting_params
     params.
       require(:setting).
-      permit(:site_title, :text_on_homepage)
+      permit(:site_title, :text_on_homepage, :amazon_affiliate_tag, :target_amazon_affiliate_tag, :nick_target_affiliate_message_by)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,4 +103,18 @@ module ApplicationHelper
 
     raw("#{pre_keyword}#{link_to_keyword}")
   end
+
+  # キーワードコマンド .a で出力された Amazon.co.jp 商品リンクに含まれる
+  # アフィリエイトタグを、設定されたタグに差し替える
+  # @param [ConversationMessage] m
+  # @return [String]
+  def replace_amazon_affiliate_tag(m)
+    settings = Setting.get
+    old_affiliate_tags = settings.target_amazon_affiliate_tags
+    new_affiliate_tag = settings.amazon_affiliate_tag
+    return m.message if old_affiliate_tags.empty? || new_affiliate_tag.blank?
+    return m.message unless settings.nicks_target_affiliate_message_by.include?(m.nick.downcase)
+
+    m.message.gsub(/(#{old_affiliate_tags.join('|')})/, new_affiliate_tag)
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,5 +1,12 @@
 class Setting < ApplicationRecord
-  before_save { nick_target_affiliate_message_by.downcase! }
+  before_save {
+    self.nick_target_affiliate_message_by =
+      delete_empty_line(nick_target_affiliate_message_by).downcase
+  }
+  before_save {
+    self.target_amazon_affiliate_tag =
+      delete_empty_line(target_amazon_affiliate_tag)
+  }
 
   validates(
     :site_title,
@@ -27,5 +34,14 @@ class Setting < ApplicationRecord
   # @return [Array<String>]
   def nicks_target_affiliate_message_by
     nick_target_affiliate_message_by.lines(chomp: true)
+  end
+
+  private
+
+  # 空行を削除する
+  # @param [String] str
+  # @return [String]
+  def delete_empty_line(str)
+    str.lines(chomp: true).delete_if{|s| s.empty? }.join("\n")
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,4 +1,6 @@
 class Setting < ApplicationRecord
+  before_save { nick_target_affiliate_message_by.downcase! }
+
   validates(
     :site_title,
     presence: true,
@@ -9,5 +11,21 @@ class Setting < ApplicationRecord
   # @return [Setting]
   def self.get
     first!
+  end
+
+  # 改行区切りテキストで保存されているため、配列に直す
+  # @return [Array<String>]
+  def target_amazon_affiliate_tags
+    target_amazon_affiliate_tag.lines(chomp: true)
+  end
+
+  def target_amazon_affiliate_tags=(new_tags)
+    target_amazon_affiliate_tag = new_tags.join("\n")
+  end
+
+  # 改行区切りテキストで保存されているため、配列に直す
+  # @return [Array<String>]
+  def nicks_target_affiliate_message_by
+    nick_target_affiliate_message_by.lines(chomp: true)
   end
 end

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -11,6 +11,23 @@
   </div>
 
   <div class="form-group">
+    <%= f.label(:target_amazon_affiliate_tag) %>
+    <%= f.text_area(:target_amazon_affiliate_tag, class: 'form-control target-amazon-affiliate-tag', 'aria-describedby' => 'target-amazon-affiliate-tag-help-block', rows: 3) %>
+    <p id="target-amazon-affiliate-tag-help-block" class="help-block">ここで指定した Amazon アフィリエイトタグを、以下で指定したものに差し替えます。<br>1行に1つずつタグを記入してください。</p>
+  </div>
+
+  <div class="form-group">
+    <%= f.label(:amazon_affiliate_tag) %>
+    <%= f.text_field(:amazon_affiliate_tag, class: 'form-control') %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label(:nick_target_affiliate_message_by) %>
+    <%= f.text_area(:nick_target_affiliate_message_by, class: 'form-control nick-target-affiliate-message-by', 'aria-describedby' => 'nick-target-affiliate-message-by-help-block', rows: 3) %>
+    <p id="nick-target-affiliate-message_by-help-block" class="help-block">ここで指定したニックネームの利用者の発言のみ、置換の対象とします。<br>1行に1つずつニックネームを記入してください。</p>
+  </div>
+
+  <div class="form-group">
     <%= f.submit(t('views.save'), class: 'btn btn-success') %>
   </div>
 <% end %>

--- a/app/views/shared/_message_content.html.erb
+++ b/app/views/shared/_message_content.html.erb
@@ -23,6 +23,6 @@
 <% when Notice, MessageHelper::IsArchived[:notice] %>
   <dl class="message">
     <dt><b class="nickname"><%= m.nick %></b></dt>
-    <dd><%= raw(convert_mirc_to_html(linkify(m.message))) %></dd>
+    <dd><%= raw(convert_mirc_to_html(linkify(replace_amazon_affiliate_tag(m)))) %></dd>
   </dl>
 <% end %>

--- a/config/locales/ja_activerecord.yml
+++ b/config/locales/ja_activerecord.yml
@@ -23,6 +23,9 @@ ja:
       setting:
         site_title: サイト名
         text_on_homepage: ホームページに表示する文章
+        target_amazon_affiliate_tag: メッセージに含まれる Amazon アフィリエイトタグ
+        amazon_affiliate_tag: 表示する Amazon アフィリエイトタグ
+        nick_target_affiliate_message_by: アフィリエイトタグを置換する発言者のニックネーム
       archive_reason:
         reason: 理由
       archived_conversation_message:

--- a/db/migrate/20210604103357_add_column_amazon_affiliate_tag_to_settings.rb
+++ b/db/migrate/20210604103357_add_column_amazon_affiliate_tag_to_settings.rb
@@ -1,5 +1,7 @@
 class AddColumnAmazonAffiliateTagToSettings < ActiveRecord::Migration[6.1]
   def change
     add_column :settings, :amazon_affiliate_tag, :string
+    add_column :settings, :target_amazon_affiliate_tag, :text
+    add_column :settings, :nick_target_affiliate_message_by, :text
   end
 end

--- a/db/migrate/20210604103357_add_column_amazon_affiliate_tag_to_settings.rb
+++ b/db/migrate/20210604103357_add_column_amazon_affiliate_tag_to_settings.rb
@@ -1,0 +1,5 @@
+class AddColumnAmazonAffiliateTagToSettings < ActiveRecord::Migration[6.1]
+  def change
+    add_column :settings, :amazon_affiliate_tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_22_045931) do
+ActiveRecord::Schema.define(version: 2021_06_04_103357) do
 
-  create_table "archive_reasons", charset: "utf8mb4", force: :cascade do |t|
+  create_table "archive_reasons", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "reason", default: "", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "archived_conversation_messages", charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "archived_conversation_messages", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "old_id", default: 0, null: false
     t.integer "channel_id"
     t.datetime "timestamp", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "channel_last_speeches", id: :integer, charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "channel_last_speeches", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "channel_id"
     t.integer "conversation_message_id"
     t.datetime "created_at", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["conversation_message_id"], name: "index_channel_last_speeches_on_conversation_message_id"
   end
 
-  create_table "channels", id: :integer, charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "channels", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "identifier", default: "", null: false
     t.boolean "logging_enabled", default: true, null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["logging_enabled"], name: "index_channels_on_logging_enabled"
   end
 
-  create_table "conversation_messages", id: :integer, charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "conversation_messages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "channel_id"
     t.datetime "timestamp", null: false
     t.string "nick", limit: 64, default: "", null: false
@@ -71,14 +71,14 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["type", "channel_id", "timestamp"], name: "index_cm_on_type_and_channel_id_and_timestamp"
   end
 
-  create_table "irc_users", id: :integer, charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "irc_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "user", limit: 64, default: "", null: false
     t.string "host", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "keywords", charset: "utf8mb4", options: "ENGINE=Mroonga", force: :cascade do |t|
+  create_table "keywords", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=Mroonga ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.string "display_title", default: "", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -87,7 +87,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["title"], name: "index_keywords_on_title", unique: true
   end
 
-  create_table "message_dates", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "message_dates", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "channel_id"
     t.date "date"
     t.datetime "created_at"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["date"], name: "index_message_dates_on_date"
   end
 
-  create_table "messages", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "messages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "channel_id"
     t.integer "irc_user_id", default: 1, null: false
     t.string "type"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["timestamp", "channel_id"], name: "index_messages_on_timestamp_and_channel_id"
   end
 
-  create_table "privmsg_keyword_relationships", charset: "utf8mb4", force: :cascade do |t|
+  create_table "privmsg_keyword_relationships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "privmsg_id"
     t.integer "keyword_id"
     t.datetime "created_at", precision: 6, null: false
@@ -121,15 +121,17 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.index ["privmsg_id"], name: "index_privmsg_keyword_relationships_on_privmsg_id"
   end
 
-  create_table "settings", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "site_title", default: "IRC ログアーカイブ", null: false
     t.text "text_on_homepage", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "amazon_affiliate_tag"
+    t.text "target_amazon_affiliate_tag"
+    t.text "nick_target_affiliate_message_by"
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "username", default: "", null: false
     t.string "email", default: "", null: false
     t.string "crypted_password"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_045931) do
     t.text "text_on_homepage", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "amazon_affiliate_tag"
   end
 
   create_table "users", id: :integer, charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
古いAmazonアフィリエイトタグを、任意のタグに差し替えられるようにしました。