### PR TITLE
yarn autoclean を有効化する

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,45 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+assets
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+
+# misc
+*.md


### PR DESCRIPTION
`yarn autoclean --init` を実行した。
`.yarnclean` ファイルが生成された。

`yarn install` / `yarn add` コマンドを実行したとき、自動的に node_modules ディレクトリ内の不要なファイルを削除するようになる。
`rails assets:precompile` でも内部的に `yarn install` が実行されるはず。

@see https://runebook.dev/ja/docs/yarn/cli/autoclean