### PR TITLE
rbenv `.ruby-version` ファイルをリポジトリに追加しないようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /config/database.yml
 /config/ircbot.yml
 /config/unicorn.rb
+/.ruby-version
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
開発環境の ruby 実行環境のバージョン指定を、リポジトリ内で管理しないようにする。