### PR TITLE
アップデートされた puma-6.0.0 では capybara-3.37.1 が動作しないため、ロールバックする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'meta-tags'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Puma as the app server
-gem 'puma'
+gem 'puma', '< 6.0'
 gem 'puma_worker_killer'
 
 # Use Capistrano for deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     psych (4.0.6)
       stringio
     public_suffix (5.0.0)
-    puma (6.0.0)
+    puma (5.6.5)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)
@@ -417,7 +417,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   net-smtp
   pry-rails
-  puma
+  puma (< 6.0)
   puma_worker_killer
   rails (~> 6.1)
   rails-controller-testing


### PR DESCRIPTION
@see https://github.com/teamcapybara/capybara/pull/2530