### PR TITLE
Webpacker を剥がして素の webpack を使うようにする

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: "Ruby 3.1: test and coverage measurement"
+    name: "Ruby 3.2: test and coverage measurement"
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: '3.2'
 
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         mroonga:
           - latest
           - mysql80-latest


### PR DESCRIPTION
rails 7.x へ更新するため、削除された webpacker を剥がして webpack を使うようにする。