### PR TITLE
mroonga 13.05 でテストを行なう

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,7 +29,7 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
@@ -46,7 +46,7 @@ jobs:
           bin/rails db:setup
       - name: Compile JavaScripts (webpack)
         run: NODE_ENV=production bin/yarn webpack
-      - uses: paambaati/codeclimate-action@v2.7.5
+      - uses: paambaati/codeclimate-action@v6.0.0
         env:
           CC_TEST_REPORTER_ID: 74e589ede57e23f089cbbd2eee75be23a93b5ace7b5cfce58213cd3f21447147
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,6 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
-        mroonga:
-          - latest
-          - mysql80-latest
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
     env:
@@ -28,7 +25,7 @@ jobs:
       TZ: Asia/Tokyo
     services:
       db:
-        image: groonga/mroonga:${{ matrix.mroonga }}
+        image: koichan779/mroonga:13.05
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: 1
         ports:


### PR DESCRIPTION
公式のDockerイメージは mysql-5.7 + mroonga 12.x から更新されていない。
そのため、自作のDockerイメージを作成し、これを使用するように切り替える。

@see https://github.com/koichan779/mroonga_rocky
@see https://hub.docker.com/r/koichan779/mroonga