### PR TITLE
bootswatch 3.3.7 -> 3.4.1 相当へ更新

### DIFF
--- a/app/assets/stylesheets/_bootswatch.scss
+++ b/app/assets/stylesheets/_bootswatch.scss
@@ -1,9 +1,11 @@
-// Flatly 3.3.7
+// Flatly 3.4.1 + cre
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" !default;
-@import url($web-font-path);
+$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700&display=swap" !default;
+@if $web-font-path {
+  @import url($web-font-path);
+}
 
 // Navbar =====================================================================
 

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,5 +1,5 @@
 $bootstrap-sass-asset-helper: false !default;
-// Flatly 3.3.7
+// Flatly 3.4.1 + cre
 // Variables
 // --------------------------------------------------
 


### PR DESCRIPTION
bootstrap 本体は v3.4.1 に更新済みであるため、プラグインである bootswatch も追従する。
色設定等の書き換えを残すため、オリジナルの差分のみ適用した。